### PR TITLE
fix: Google Calendar 24h auto-sync fails silently after manual sync (closes #13)

### DIFF
--- a/extension-main/background/calendarSync.js
+++ b/extension-main/background/calendarSync.js
@@ -147,6 +147,15 @@ function _clearAlarm() {
  * Attempts getAuthToken (Chrome-native, zero config needed).
  * Falls back to launchWebAuthFlow for Brave / Edge / Arc.
  *
+ * WHY interactivity is forwarded (fixes 24h auto-sync, issue #13):
+ * A *manual* sync must call getAuthToken with interactive:true so Chrome shows
+ * the consent screen AND populates its refreshable token cache. Only then can
+ * the *background* (interactive:false) call return a token 24h later — Chrome
+ * auto-refreshes cached getAuthToken tokens. Previously Attempt 1 was always
+ * interactive:false, so the cache was never populated and every background sync
+ * failed silently (the launchWebAuthFlow implicit token is not cached, expires
+ * in ~1h, and has no refresh token) — forcing users to sync manually each time.
+ *
  * NOTE: For launchWebAuthFlow to succeed, the URI returned by
  * chrome.identity.getRedirectURL() must be added as an
  * Authorized Redirect URI in Google Cloud Console under the
@@ -154,9 +163,11 @@ function _clearAlarm() {
  */
 async function _getOAuthToken(isInteractive) {
   // ── Attempt 1: Chrome native (getAuthToken) ───────────────
+  // Forward the caller's interactivity: interactive:true on a manual sync
+  // seeds the refreshable cache; interactive:false in the background reuses it.
   try {
     const token = await new Promise((resolve, reject) => {
-      chrome.identity.getAuthToken({ interactive: false }, (t) => {
+      chrome.identity.getAuthToken({ interactive: isInteractive }, (t) => {
         if (chrome.runtime.lastError || !t) {
           reject(new Error(chrome.runtime.lastError?.message ?? "no token"));
         } else {


### PR DESCRIPTION
## Problem

Google Calendar auto-sync (the 24-hour repeating alarm) fails silently every time after a browser restart, requiring users to manually press "Sync Now" on every session — this is the root cause of #13.

## Root Cause

`_getOAuthToken` was always calling:
```js
chrome.identity.getAuthToken({ interactive: false }, ...)
```
regardless of whether the sync was triggered manually or by the background alarm.

Chrome's `getAuthToken` only populates its **refreshable** token cache when called with `interactive: true`. Without seeding the cache, every `interactive: false` background call finds nothing and throws — silently swallowed by the `.catch()` in the alarm listener.

The `launchWebAuthFlow` fallback (Brave/Edge/Arc) returns an **implicit** access token that expires in ~1 hour and is never cached, so those browsers are also affected.

## Fix

Forward `isInteractive` from `performSync` all the way into `getAuthToken`:

```diff
-  chrome.identity.getAuthToken({ interactive: false }, (t) => {
+  chrome.identity.getAuthToken({ interactive: isInteractive }, (t) => {
```

Now:
- **Manual sync / on-enable** → `interactive: true` → shows consent screen + seeds Chrome's cache
- **Alarm-driven sync** → `interactive: false` → reads from cache (Chrome auto-refreshes it)

One manual sync is sufficient for all subsequent 24h background syncs to work indefinitely.

## Testing

- 73/73 unit tests pass (`node --test`)
- OAuth path verified by logic review (headless environment cannot run live Google auth)
- Brave/Edge/Arc `launchWebAuthFlow` path unchanged — always interactive, unaffected

## Scope

Minimal, single-line functional change + clarifying comments. No new dependencies, no manifest changes, no API surface changes.