### PR TITLE
feat: Video End Time display with custom speed slider & hotkeys

### DIFF
--- a/extension-main/content/cleaner/selectors.js
+++ b/extension-main/content/cleaner/selectors.js
@@ -51,6 +51,10 @@ const DEFAULT_SETTINGS = {
   // Spotlight Search
   "spotlight-search": true,
 
+  // Video End Time
+  "video-end-time": true,
+  "video-end-time-speed": true,
+
   // Appearance — site-wide theme ("off" = native Scaler look)
   theme: "off",
 };

--- a/extension-main/content/content.js
+++ b/extension-main/content/content.js
@@ -117,6 +117,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       if (!value && typeof closeSpotlight === "function") {
         closeSpotlight();
       }
+    } else if (key === "video-end-time") {
+      if (value) {
+        if (typeof initVideoEndTime === "function") initVideoEndTime();
+      } else {
+        removeEndTimeOverlay();
+      }
+    } else if (key === "video-end-time-speed") {
+      // Changing speed toggle requires re-injection
+      removeEndTimeOverlay();
+      if (value && currentSettings["video-end-time"]) {
+        if (typeof initVideoEndTime === "function") initVideoEndTime();
+      }
     } else if (key === "theme") {
       // Site-wide theme switch — value is a theme id ("off", "dark", ...)
       if (typeof applyTheme === "function") applyTheme(value);
@@ -235,6 +247,13 @@ window.addEventListener("load", async () => {
 
   // Initialize Spotlight Search (Ctrl+Space)
   if (typeof initSpotlightSearch === "function") initSpotlightSearch();
+
+  // Initialize Video End Time on session/recording pages
+  setTimeout(() => {
+    if (currentSettings && currentSettings["video-end-time"] && typeof initVideoEndTime === "function") {
+      initVideoEndTime();
+    }
+  }, 2000);
 });
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -305,4 +324,11 @@ handleUrlChange = function () {
 
   // Re-initialize Problem Picker on dashboard
   setTimeout(initProblemPicker, 1500);
+
+  // Re-initialize Video End Time on session/recording pages after navigation
+  setTimeout(() => {
+    if (currentSettings && currentSettings["video-end-time"] && typeof initVideoEndTime === "function") {
+      initVideoEndTime();
+    }
+  }, 2000);
 };

--- a/extension-main/content/features/videoEndTime.js
+++ b/extension-main/content/features/videoEndTime.js
@@ -1,0 +1,373 @@
+// ============================================
+// features/videoEndTime.js
+// Shows video end time on Scaler's player with custom playback speed control.
+//
+// Merged from the YouTime (YouTube) and TimeScale (Scaler) Chrome extensions.
+//
+// Features:
+//   - "Ends at: HH:MM" display next to the video progress bar
+//   - Custom playback speed input (0.1x – 16x, beyond Scaler's 2x UI limit)
+//   - Keyboard shortcuts: Shift+. speed up, Shift+, slow down (0.25x steps)
+//   - Speed persisted via localStorage
+//   - Applies speed directly to the <video> element (bypasses UI limit)
+// ============================================
+
+const VIDEO_END_TIME_ATTR = "data-scaler-end-time";
+const VIDEO_END_TIME_CLASS = "scaler-end-time";
+const SPEED_INPUT_CLASS = "scaler-speed-input";
+const SPEED_TOOLTIP_ID = "scaler-speed-tooltip";
+
+// LocalStorage key for persisting custom speed
+const CUSTOM_SPEED_KEY = "scaler-custom-speed";
+
+// Speed step for hotkey adjustments
+const SPEED_STEP = 0.25;
+
+// Speed presets for quick cycling
+const SPEED_PRESETS = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 12, 16];
+
+/**
+ * Find the next speed preset above the current value.
+ */
+function nextSpeedPreset(current) {
+  for (const s of SPEED_PRESETS) {
+    if (s > current + 0.01) return s;
+  }
+  return Math.min(current + SPEED_STEP, 16);
+}
+
+/**
+ * Find the previous speed preset below the current value.
+ */
+function prevSpeedPreset(current) {
+  for (let i = SPEED_PRESETS.length - 1; i >= 0; i--) {
+    if (SPEED_PRESETS[i] < current - 0.01) return SPEED_PRESETS[i];
+  }
+  return Math.max(current - SPEED_STEP, 0.1);
+}
+
+/**
+ * Find the Scaler video player element.
+ * Handles multiple selectors for different Scaler page layouts.
+ */
+function findScalerVideo() {
+  return (
+    document.querySelector(".vp-video") ||
+    document.querySelector("video.vp-video") ||
+    document.querySelector("[data-cy='archived-meeting-video-player']") ||
+    document.querySelector("video")
+  );
+}
+
+/**
+ * Find the time display container next to the video controls.
+ */
+function findTimeDisplay() {
+  return document.querySelector(".vp-controls__duration");
+}
+
+/**
+ * Format a Date object to a locale time string (HH:MM AM/PM).
+ */
+function formatEndTime(date) {
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Show a brief tooltip near the player indicating the new speed.
+ */
+function showSpeedTooltip(speed) {
+  // Remove any existing tooltip
+  const existing = document.getElementById(SPEED_TOOLTIP_ID);
+  if (existing) existing.remove();
+
+  const tooltip = document.createElement("div");
+  tooltip.id = SPEED_TOOLTIP_ID;
+  tooltip.textContent = speed.toFixed(2) + "x";
+  tooltip.style.cssText = `
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    font-size: 28px;
+    font-weight: 700;
+    padding: 12px 28px;
+    border-radius: 12px;
+    z-index: 999999;
+    pointer-events: none;
+    animation: scaler-speed-fade 1.2s ease-out forwards;
+  `;
+
+  // Inject keyframe animation once
+  if (!document.getElementById("scaler-speed-keyframes")) {
+    const style = document.createElement("style");
+    style.id = "scaler-speed-keyframes";
+    style.textContent = `
+      @keyframes scaler-speed-fade {
+        0% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+        60% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+        100% { opacity: 0; transform: translate(-50%, -50%) scale(0.9); }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  document.body.appendChild(tooltip);
+
+  // Auto-remove after animation
+  setTimeout(() => tooltip.remove(), 1300);
+}
+
+/**
+ * Apply playback speed to the video element.
+ * Bypasses Scaler's UI-enforced 2x limit by setting video.playbackRate directly.
+ */
+function applyPlaybackSpeed(video, speed) {
+  if (!video) return;
+  const rate = Math.max(0.1, Math.min(16, parseFloat(speed) || 1));
+  video.playbackRate = rate;
+
+  // Also try to update any native speed indicators Scaler might have
+  const speedButtons = document.querySelectorAll(
+    ".vp-speed-btn, .vp-controls__speed, [data-cy='video-player-speed']"
+  );
+  speedButtons.forEach((btn) => {
+    const label = btn.querySelector("span, .vp-speed-label");
+    if (label) label.textContent = rate.toFixed(1) + "x";
+  });
+
+  return rate;
+}
+
+/**
+ * Sync the speed input field with the current speed value.
+ */
+function syncSpeedInput(speed) {
+  const input = document.querySelector(`.${SPEED_INPUT_CLASS}`);
+  if (input) {
+    input.value = speed.toFixed(1);
+  }
+}
+
+/**
+ * Inject the end-time overlay + speed input next to the time display.
+ */
+function injectEndTimeOverlay() {
+  const video = findScalerVideo();
+  const timeDisplay = findTimeDisplay();
+
+  if (!video || !timeDisplay) return;
+
+  // Don't duplicate if already injected
+  if (document.querySelector(`[${VIDEO_END_TIME_ATTR}]`)) return;
+
+  // --- Restore saved speed and apply to video ---
+  const savedSpeed = parseFloat(localStorage.getItem(CUSTOM_SPEED_KEY));
+  const initialSpeed =
+    savedSpeed && savedSpeed > 0 ? savedSpeed : video.playbackRate || 1;
+  applyPlaybackSpeed(video, initialSpeed);
+
+  // --- Build the container ---
+  const container = document.createElement("div");
+  container.style.display = "flex";
+  container.style.alignItems = "center";
+  container.style.gap = "8px";
+  container.setAttribute(VIDEO_END_TIME_ATTR, "true");
+
+  // End time display (styled like vp-controls__duration)
+  const endTimeDiv = document.createElement("div");
+  endTimeDiv.className = `vp-controls__duration ${VIDEO_END_TIME_CLASS}`;
+  endTimeDiv.setAttribute("data-cy", "video-player-end-time");
+  endTimeDiv.style.fontSize = "12px";
+  container.appendChild(endTimeDiv);
+
+  // --- Custom speed input ---
+  if (currentSettings && currentSettings["video-end-time-speed"]) {
+    const speedContainer = document.createElement("div");
+    speedContainer.style.display = "flex";
+    speedContainer.style.alignItems = "center";
+    speedContainer.style.gap = "4px";
+    speedContainer.style.fontSize = "12px";
+    speedContainer.style.color = "white";
+
+    const speedLabel = document.createElement("span");
+    speedLabel.textContent = "Speed:";
+    speedLabel.style.fontSize = "11px";
+    speedContainer.appendChild(speedLabel);
+
+    const speedInput = document.createElement("input");
+    speedInput.type = "number";
+    speedInput.step = "0.1";
+    speedInput.min = "0.1";
+    speedInput.max = "16";
+    speedInput.className = SPEED_INPUT_CLASS;
+    speedInput.style.width = "55px";
+    speedInput.style.padding = "2px 5px";
+    speedInput.style.fontSize = "12px";
+    speedInput.style.backgroundColor = "rgba(255, 255, 255, 0.1)";
+    speedInput.style.border = "1px solid rgba(255, 255, 255, 0.3)";
+    speedInput.style.borderRadius = "3px";
+    speedInput.style.color = "white";
+    speedInput.style.textAlign = "center";
+
+    speedInput.value = initialSpeed;
+
+    // --- Speed input change: apply to video immediately ---
+    speedInput.addEventListener("change", () => {
+      const newSpeed = parseFloat(speedInput.value) || 1;
+      const clamped = Math.max(0.1, Math.min(16, newSpeed));
+      localStorage.setItem(CUSTOM_SPEED_KEY, clamped);
+      speedInput.value = clamped;
+      applyPlaybackSpeed(video, clamped);
+      showSpeedTooltip(clamped);
+      updateEndTime();
+    });
+
+    // Also update on Enter key
+    speedInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        speedInput.blur(); // triggers change event
+      }
+    });
+
+    speedContainer.appendChild(speedInput);
+    speedContainer.appendChild(document.createTextNode("x"));
+    container.appendChild(speedContainer);
+  }
+
+  // Insert after the time display
+  timeDisplay.parentNode.insertBefore(container, timeDisplay.nextSibling);
+
+  // --- Update loop ---
+  function updateEndTime() {
+    if (!video || !video.duration || video.duration === Infinity) return;
+
+    const currentTime = video.currentTime;
+    const duration = video.duration;
+    const playbackRate = video.playbackRate || 1;
+
+    if (duration && currentTime !== undefined && playbackRate > 0) {
+      const adjustedRemaining = (duration - currentTime) / playbackRate;
+      const endTime = new Date(Date.now() + adjustedRemaining * 1000);
+      endTimeDiv.textContent = `Ends at: ${formatEndTime(endTime)}`;
+    }
+  }
+
+  // Initial update
+  updateEndTime();
+
+  // Keep updating every second
+  const intervalId = setInterval(updateEndTime, 1000);
+
+  // Store interval and video ref on the container for cleanup
+  container._endTimeInterval = intervalId;
+  container._videoRef = video;
+
+  // --- Sync speed input when video playbackRate changes externally ---
+  // Some players modify playbackRate themselves (e.g. native speed buttons)
+  container._rateChangeHandler = () => {
+    syncSpeedInput(video.playbackRate);
+    updateEndTime();
+  };
+  video.addEventListener("ratechange", container._rateChangeHandler);
+}
+
+/**
+ * Remove the end-time overlay from the DOM and clean up.
+ */
+function removeEndTimeOverlay() {
+  const overlay = document.querySelector(`[${VIDEO_END_TIME_ATTR}]`);
+  if (overlay) {
+    if (overlay._endTimeInterval) {
+      clearInterval(overlay._endTimeInterval);
+    }
+    if (overlay._rateChangeHandler && overlay._videoRef) {
+      overlay._videoRef.removeEventListener(
+        "ratechange",
+        overlay._rateChangeHandler
+      );
+    }
+    overlay.remove();
+  }
+
+  // Disconnect observer
+  if (window._endTimeObserver) {
+    window._endTimeObserver.disconnect();
+    window._endTimeObserver = null;
+  }
+
+  // Remove hotkey listener
+  if (window._endTimeHotkeyHandler) {
+    document.removeEventListener("keydown", window._endTimeHotkeyHandler);
+    window._endTimeHotkeyHandler = null;
+  }
+}
+
+/**
+ * Set up keyboard shortcuts for speed control.
+ * Shift+. (>) = speed up    Shift+, (<) = slow down
+ */
+function setupSpeedHotkeys() {
+  if (window._endTimeHotkeyHandler) return; // already set up
+
+  const handler = (e) => {
+    // Only when speed feature is enabled
+    if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
+
+    // Only when a video is present on the page
+    const video = findScalerVideo();
+    if (!video) return;
+
+    // Shift + . (period) = speed up
+    if (e.shiftKey && e.key === ".") {
+      e.preventDefault();
+      const current = video.playbackRate || 1;
+      const newSpeed = nextSpeedPreset(current);
+      applyPlaybackSpeed(video, newSpeed);
+      syncSpeedInput(newSpeed);
+      localStorage.setItem(CUSTOM_SPEED_KEY, newSpeed);
+      showSpeedTooltip(newSpeed);
+    }
+
+    // Shift + , (comma) = slow down
+    if (e.shiftKey && e.key === ",") {
+      e.preventDefault();
+      const current = video.playbackRate || 1;
+      const newSpeed = prevSpeedPreset(current);
+      applyPlaybackSpeed(video, newSpeed);
+      syncSpeedInput(newSpeed);
+      localStorage.setItem(CUSTOM_SPEED_KEY, newSpeed);
+      showSpeedTooltip(newSpeed);
+    }
+  };
+
+  document.addEventListener("keydown", handler);
+  window._endTimeHotkeyHandler = handler;
+}
+
+/**
+ * Initialize the video end time feature.
+ */
+function initVideoEndTime() {
+  // Don't double-init
+  if (window._endTimeObserver) return;
+
+  // Try injecting immediately (player might already be in DOM)
+  injectEndTimeOverlay();
+
+  // Watch for DOM changes (SPA navigation, player appearing)
+  const observer = new MutationObserver(() => {
+    injectEndTimeOverlay();
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+  window._endTimeObserver = observer;
+
+  // Set up speed hotkeys
+  setupSpeedHotkeys();
+}

--- a/extension-main/content/features/videoEndTime.js
+++ b/extension-main/content/features/videoEndTime.js
@@ -1,55 +1,27 @@
 // ============================================
 // features/videoEndTime.js
-// Shows video end time on Scaler's player with custom playback speed control.
+// Video end time display + extended speed dropdown + hotkeys
 //
-// Merged from the YouTime (YouTube) and TimeScale (Scaler) Chrome extensions.
-//
-// Features:
-//   - "Ends at: HH:MM" display next to the video progress bar
-//   - Custom playback speed input (0.1x – 16x, beyond Scaler's 2x UI limit)
-//   - Keyboard shortcuts: Shift+. speed up, Shift+, slow down (0.25x steps)
-//   - Speed persisted via localStorage
-//   - Applies speed directly to the <video> element (bypasses UI limit)
+// Shows "Ends at: HH:MM" on Scaler's video player, styled to match
+// the native control bar. Extends the existing playback speed
+// dropdown with values beyond 2x (up to 16x). Keyboard shortcuts
+// allow quick speed changes (Shift+. speed up, Shift+, slow down).
 // ============================================
 
 const VIDEO_END_TIME_ATTR = "data-scaler-end-time";
-const VIDEO_END_TIME_CLASS = "scaler-end-time";
-const SPEED_INPUT_CLASS = "scaler-speed-input";
-const SPEED_TOOLTIP_ID = "scaler-speed-tooltip";
+const SCALER_EXTRA_ITEM = "scaler-extra-speed";
+const SCALER_SPEED_ATTR = "data-scaler-custom-speed";
 
-// LocalStorage key for persisting custom speed
 const CUSTOM_SPEED_KEY = "scaler-custom-speed";
+const EXTRA_SPEEDS = [2.5, 3, 4, 6, 8, 12, 16];
+const SPEED_PRESETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 12, 16];
 
-// Speed step for hotkey adjustments
-const SPEED_STEP = 0.25;
+// Store the last custom speed so we can re-apply it if Scaler resets it
+let _lastCustomSpeed = null;
+let _speedGuardInterval = null;
 
-// Speed presets for quick cycling
-const SPEED_PRESETS = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 12, 16];
+// ─── Helpers ──────────────────────────────────────
 
-/**
- * Find the next speed preset above the current value.
- */
-function nextSpeedPreset(current) {
-  for (const s of SPEED_PRESETS) {
-    if (s > current + 0.01) return s;
-  }
-  return Math.min(current + SPEED_STEP, 16);
-}
-
-/**
- * Find the previous speed preset below the current value.
- */
-function prevSpeedPreset(current) {
-  for (let i = SPEED_PRESETS.length - 1; i >= 0; i--) {
-    if (SPEED_PRESETS[i] < current - 0.01) return SPEED_PRESETS[i];
-  }
-  return Math.max(current - SPEED_STEP, 0.1);
-}
-
-/**
- * Find the Scaler video player element.
- * Handles multiple selectors for different Scaler page layouts.
- */
 function findScalerVideo() {
   return (
     document.querySelector(".vp-video") ||
@@ -59,16 +31,25 @@ function findScalerVideo() {
   );
 }
 
-/**
- * Find the time display container next to the video controls.
- */
 function findTimeDisplay() {
   return document.querySelector(".vp-controls__duration");
 }
 
-/**
- * Format a Date object to a locale time string (HH:MM AM/PM).
- */
+function findSpeedTitle() {
+  return document.querySelector(".vp-playback-title");
+}
+
+function findSpeedButton() {
+  return document.querySelector(
+    "[data-cy='video-player-controls-playback-rate-button'], .vp-dropdown"
+  );
+}
+
+function findDropdownContainer() {
+  const btn = findSpeedButton();
+  return btn ? btn.closest(".dropdown") : null;
+}
+
 function formatEndTime(date) {
   return date.toLocaleTimeString([], {
     hour: "2-digit",
@@ -76,216 +57,392 @@ function formatEndTime(date) {
   });
 }
 
-/**
- * Show a brief tooltip near the player indicating the new speed.
- */
-function showSpeedTooltip(speed) {
-  // Remove any existing tooltip
-  const existing = document.getElementById(SPEED_TOOLTIP_ID);
-  if (existing) existing.remove();
+// ─── Speed Application ──────────────────────────
 
-  const tooltip = document.createElement("div");
-  tooltip.id = SPEED_TOOLTIP_ID;
-  tooltip.textContent = speed.toFixed(2) + "x";
-  tooltip.style.cssText = `
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: rgba(0, 0, 0, 0.85);
-    color: #fff;
-    font-size: 28px;
-    font-weight: 700;
-    padding: 12px 28px;
-    border-radius: 12px;
-    z-index: 999999;
-    pointer-events: none;
-    animation: scaler-speed-fade 1.2s ease-out forwards;
-  `;
-
-  // Inject keyframe animation once
-  if (!document.getElementById("scaler-speed-keyframes")) {
-    const style = document.createElement("style");
-    style.id = "scaler-speed-keyframes";
-    style.textContent = `
-      @keyframes scaler-speed-fade {
-        0% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
-        60% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
-        100% { opacity: 0; transform: translate(-50%, -50%) scale(0.9); }
-      }
-    `;
-    document.head.appendChild(style);
-  }
-
-  document.body.appendChild(tooltip);
-
-  // Auto-remove after animation
-  setTimeout(() => tooltip.remove(), 1300);
-}
-
-/**
- * Apply playback speed to the video element.
- * Bypasses Scaler's UI-enforced 2x limit by setting video.playbackRate directly.
- */
 function applyPlaybackSpeed(video, speed) {
-  if (!video) return;
+  if (!video) return false;
   const rate = Math.max(0.1, Math.min(16, parseFloat(speed) || 1));
   video.playbackRate = rate;
+  _lastCustomSpeed = rate;
 
-  // Also try to update any native speed indicators Scaler might have
-  const speedButtons = document.querySelectorAll(
-    ".vp-speed-btn, .vp-controls__speed, [data-cy='video-player-speed']"
-  );
-  speedButtons.forEach((btn) => {
-    const label = btn.querySelector("span, .vp-speed-label");
-    if (label) label.textContent = rate.toFixed(1) + "x";
-  });
+  // Update dropdown title
+  const title = findSpeedTitle();
+  if (title) {
+    const display = rate === Math.round(rate) ? rate + "" : rate.toFixed(2);
+    title.textContent = display + "x";
+  }
 
+  localStorage.setItem(CUSTOM_SPEED_KEY, String(rate));
   return rate;
 }
 
-/**
- * Sync the speed input field with the current speed value.
- */
-function syncSpeedInput(speed) {
-  const input = document.querySelector(`.${SPEED_INPUT_CLASS}`);
-  if (input) {
-    input.value = speed.toFixed(1);
+// ─── Speed Guardian ────────────────────────────
+// Scaler's player may reset playbackRate on various events (seeking,
+// source change, fullscreen toggle, etc.).  This runs a tick every
+// 600ms and re-applies the custom speed if the player changed it.
+
+function _startSpeedGuard() {
+  if (_speedGuardInterval) return;
+  _speedGuardInterval = setInterval(() => {
+    if (!_lastCustomSpeed) return;
+    const video = findScalerVideo();
+    if (!video || !video.duration) return;
+    // If the player's rate differs from ours and it's outside our range
+    if (Math.abs(video.playbackRate - _lastCustomSpeed) > 0.01) {
+      // Only re-apply if our speed is >2x (native speeds are handled by Scaler)
+      // or if it's clearly a reset (back to 1x while we were at e.g. 1.5x)
+      const isNative = video.playbackRate <= 2 && _lastCustomSpeed <= 2;
+      if (!isNative) {
+        video.playbackRate = _lastCustomSpeed;
+      }
+    }
+  }, 600);
+}
+
+function _stopSpeedGuard() {
+  if (_speedGuardInterval) {
+    clearInterval(_speedGuardInterval);
+    _speedGuardInterval = null;
   }
 }
 
-/**
- * Inject the end-time overlay + speed input next to the time display.
- */
+// ─── End Time Overlay ────────────────────────────
+
 function injectEndTimeOverlay() {
   const video = findScalerVideo();
   const timeDisplay = findTimeDisplay();
-
   if (!video || !timeDisplay) return;
-
-  // Don't duplicate if already injected
   if (document.querySelector(`[${VIDEO_END_TIME_ATTR}]`)) return;
 
-  // --- Restore saved speed and apply to video ---
-  const savedSpeed = parseFloat(localStorage.getItem(CUSTOM_SPEED_KEY));
-  const initialSpeed =
-    savedSpeed && savedSpeed > 0 ? savedSpeed : video.playbackRate || 1;
-  applyPlaybackSpeed(video, initialSpeed);
+  // Restore saved speed
+  const saved = parseFloat(localStorage.getItem(CUSTOM_SPEED_KEY));
+  if (saved && saved > 0 && Math.abs(saved - video.playbackRate) > 0.01) {
+    applyPlaybackSpeed(video, saved);
+  }
 
-  // --- Build the container ---
   const container = document.createElement("div");
+  container.setAttribute(VIDEO_END_TIME_ATTR, "true");
   container.style.display = "flex";
   container.style.alignItems = "center";
   container.style.gap = "8px";
-  container.setAttribute(VIDEO_END_TIME_ATTR, "true");
+  container.style.flexShrink = "0";
 
-  // End time display (styled like vp-controls__duration)
   const endTimeDiv = document.createElement("div");
-  endTimeDiv.className = `vp-controls__duration ${VIDEO_END_TIME_CLASS}`;
-  endTimeDiv.setAttribute("data-cy", "video-player-end-time");
-  endTimeDiv.style.fontSize = "12px";
+  endTimeDiv.className = "vp-controls__duration";
+  endTimeDiv.style.whiteSpace = "nowrap";
+  endTimeDiv.style.fontSize = "inherit";
   container.appendChild(endTimeDiv);
 
-  // --- Custom speed input ---
-  if (currentSettings && currentSettings["video-end-time-speed"]) {
-    const speedContainer = document.createElement("div");
-    speedContainer.style.display = "flex";
-    speedContainer.style.alignItems = "center";
-    speedContainer.style.gap = "4px";
-    speedContainer.style.fontSize = "12px";
-    speedContainer.style.color = "white";
-
-    const speedLabel = document.createElement("span");
-    speedLabel.textContent = "Speed:";
-    speedLabel.style.fontSize = "11px";
-    speedContainer.appendChild(speedLabel);
-
-    const speedInput = document.createElement("input");
-    speedInput.type = "number";
-    speedInput.step = "0.1";
-    speedInput.min = "0.1";
-    speedInput.max = "16";
-    speedInput.className = SPEED_INPUT_CLASS;
-    speedInput.style.width = "55px";
-    speedInput.style.padding = "2px 5px";
-    speedInput.style.fontSize = "12px";
-    speedInput.style.backgroundColor = "rgba(255, 255, 255, 0.1)";
-    speedInput.style.border = "1px solid rgba(255, 255, 255, 0.3)";
-    speedInput.style.borderRadius = "3px";
-    speedInput.style.color = "white";
-    speedInput.style.textAlign = "center";
-
-    speedInput.value = initialSpeed;
-
-    // --- Speed input change: apply to video immediately ---
-    speedInput.addEventListener("change", () => {
-      const newSpeed = parseFloat(speedInput.value) || 1;
-      const clamped = Math.max(0.1, Math.min(16, newSpeed));
-      localStorage.setItem(CUSTOM_SPEED_KEY, clamped);
-      speedInput.value = clamped;
-      applyPlaybackSpeed(video, clamped);
-      showSpeedTooltip(clamped);
-      updateEndTime();
-    });
-
-    // Also update on Enter key
-    speedInput.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") {
-        speedInput.blur(); // triggers change event
-      }
-    });
-
-    speedContainer.appendChild(speedInput);
-    speedContainer.appendChild(document.createTextNode("x"));
-    container.appendChild(speedContainer);
-  }
-
-  // Insert after the time display
+  // Insert after the native duration
   timeDisplay.parentNode.insertBefore(container, timeDisplay.nextSibling);
 
-  // --- Update loop ---
   function updateEndTime() {
     if (!video || !video.duration || video.duration === Infinity) return;
-
-    const currentTime = video.currentTime;
-    const duration = video.duration;
-    const playbackRate = video.playbackRate || 1;
-
-    if (duration && currentTime !== undefined && playbackRate > 0) {
-      const adjustedRemaining = (duration - currentTime) / playbackRate;
-      const endTime = new Date(Date.now() + adjustedRemaining * 1000);
-      endTimeDiv.textContent = `Ends at: ${formatEndTime(endTime)}`;
-    }
+    const remaining =
+      (video.duration - video.currentTime) / (video.playbackRate || 1);
+    const endTime = new Date(Date.now() + remaining * 1000);
+    endTimeDiv.textContent = `Ends at: ${formatEndTime(endTime)}`;
   }
 
-  // Initial update
   updateEndTime();
-
-  // Keep updating every second
   const intervalId = setInterval(updateEndTime, 1000);
-
-  // Store interval and video ref on the container for cleanup
   container._endTimeInterval = intervalId;
   container._videoRef = video;
 
-  // --- Sync speed input when video playbackRate changes externally ---
-  // Some players modify playbackRate themselves (e.g. native speed buttons)
-  container._rateChangeHandler = () => {
-    syncSpeedInput(video.playbackRate);
-    updateEndTime();
-  };
-  video.addEventListener("ratechange", container._rateChangeHandler);
+  const rateHandler = () => updateEndTime();
+  video.addEventListener("ratechange", rateHandler);
+  container._rateChangeHandler = rateHandler;
+}
+
+// ─── Speed Dropdown Extension ───────────────────
+
+/**
+ * Find the actual dropdown menu that contains speed options.
+ * Scaler's dropdown may vary in structure, so we try multiple strategies.
+ */
+function findSpeedMenu() {
+  const container = findDropdownContainer();
+  if (!container) return null;
+
+  // Strategy 1: standard dropdown menu class
+  let menu = container.querySelector(
+    ".dropdown__items, .dropdown__menu, [role='menu'], .vp-dropdown-items, .vp-playback-menu"
+  );
+  if (menu) return menu;
+
+  // Strategy 2: look for a sibling/child div that becomes visible when dropdown is open
+  const allChildren = container.querySelectorAll(":scope > div, :scope > ul, :scope > section");
+  for (const child of allChildren) {
+    if (child !== findSpeedButton() && child.offsetParent !== null) {
+      const items = child.querySelectorAll("a, button, div[role='menuitem'], .dropdown__item");
+      if (items.length >= 3) return child; // looks like a menu with items
+    }
+  }
+
+  // Strategy 3: the menu might be outside the .dropdown container but attached to body
+  // Look for visible menus
+  const visibleMenus = document.querySelectorAll(
+    ".dropdown__items:not([hidden]), .dropdown__menu:not([hidden]), [role='menu']:not([hidden])"
+  );
+  for (const m of visibleMenus) {
+    if (m.textContent.includes("1x") && m.textContent.includes("2x")) {
+      return m;
+    }
+  }
+
+  return null;
+}
+
+function injectExtraSpeedOptions() {
+  if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
+
+  const menu = findSpeedMenu();
+  if (!menu) return;
+
+  // Already injected?
+  if (menu.querySelector(`.${SCALER_EXTRA_ITEM}`)) return;
+
+  // Find last native item (look for anything containing a speed value)
+  const allItems = menu.querySelectorAll(
+    "[role='menuitem'], .dropdown__item, a, button, div"
+  );
+  let lastItem = null;
+  for (const item of allItems) {
+    if (item.closest(`.${SCALER_EXTRA_ITEM}`)) continue; // skip our own
+    const text = item.textContent.trim();
+    if (/^\d+(\.\d+)?x$/.test(text)) {
+      lastItem = item;
+    }
+  }
+
+  if (!lastItem) return;
+
+  // Divider
+  const divider = document.createElement("div");
+  divider.className = `${SCALER_EXTRA_ITEM} dropdown__divider`;
+  divider.style.cssText =
+    "height:1px;background:rgba(255,255,255,0.15);margin:4px 12px;";
+  lastItem.parentNode.insertBefore(divider, lastItem.nextSibling);
+
+  // Extra speed items (insert after divider)
+  EXTRA_SPEEDS.forEach((speed) => {
+    const item = document.createElement("div");
+    item.className = `dropdown__item ${SCALER_EXTRA_ITEM}`;
+    item.setAttribute("role", "menuitem");
+    item.setAttribute(SCALER_SPEED_ATTR, String(speed));
+    item.textContent = speed + "x";
+    item.style.cursor = "pointer";
+
+    item.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const video = findScalerVideo();
+      if (video) {
+        applyPlaybackSpeed(video, speed);
+        showSpeedTooltip(speed);
+        _startSpeedGuard();
+      }
+      dismissDropdown();
+    });
+
+    divider.parentNode.insertBefore(item, divider.nextSibling);
+  });
 }
 
 /**
- * Remove the end-time overlay from the DOM and clean up.
+ * Try to dismiss the open speed dropdown by dispatching Escape.
  */
+function dismissDropdown() {
+  // Dispatch Escape in both capture and bubble
+  document.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Escape",
+    code: "Escape",
+    bubbles: true,
+    cancelable: true,
+  }));
+}
+
+// ─── Tooltip ─────────────────────────────────────
+
+function showSpeedTooltip(speed) {
+  const existing = document.getElementById("scaler-speed-tip");
+  if (existing) existing.remove();
+
+  const tip = document.createElement("div");
+  tip.id = "scaler-speed-tip";
+  tip.textContent = speed + "x";
+  tip.style.cssText = `
+    position:fixed; top:50%; left:50%;
+    transform:translate(-50%,-50%);
+    background:rgba(0,0,0,0.85); color:#fff;
+    font-size:28px; font-weight:700;
+    padding:12px 28px; border-radius:12px;
+    z-index:999999; pointer-events:none;
+    animation:speed-tip-fade 1.2s ease-out forwards;
+  `;
+
+  if (!document.getElementById("speed-tip-keyframes")) {
+    const s = document.createElement("style");
+    s.id = "speed-tip-keyframes";
+    s.textContent = `
+      @keyframes speed-tip-fade {
+        0% { opacity:1; transform:translate(-50%,-50%) scale(1); }
+        60% { opacity:1; transform:translate(-50%,-50%) scale(1.05); }
+        100% { opacity:0; transform:translate(-50%,-50%) scale(0.9); }
+      }
+    `;
+    document.head.appendChild(s);
+  }
+
+  document.body.appendChild(tip);
+  setTimeout(() => tip.remove(), 1300);
+}
+
+// ─── Hotkeys ─────────────────────────────────────
+
+function nextSpeed(current) {
+  for (const s of SPEED_PRESETS) {
+    if (s > current + 0.01) return s;
+  }
+  return SPEED_PRESETS[SPEED_PRESETS.length - 1];
+}
+
+function prevSpeed(current) {
+  for (let i = SPEED_PRESETS.length - 1; i >= 0; i--) {
+    if (SPEED_PRESETS[i] < current - 0.01) return SPEED_PRESETS[i];
+  }
+  return SPEED_PRESETS[0];
+}
+
+function setupSpeedHotkeys() {
+  if (window._scalerSpeedHotkey) return;
+
+  const handler = (e) => {
+    if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
+    const video = findScalerVideo();
+    if (!video || !video.duration) return;
+
+    let handled = false;
+    let newSpeed = null;
+
+    // Shift + Period (>) = speed up
+    if (e.shiftKey && (e.code === "Period" || e.key === ">" || e.key === ".")) {
+      const cur = video.playbackRate || 1;
+      newSpeed = nextSpeed(cur);
+      handled = true;
+    }
+
+    // Shift + Comma (<) = slow down
+    if (e.shiftKey && (e.code === "Comma" || e.key === "<" || e.key === ",")) {
+      const cur = video.playbackRate || 1;
+      newSpeed = prevSpeed(cur);
+      handled = true;
+    }
+
+    if (handled && newSpeed !== null) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      applyPlaybackSpeed(video, newSpeed);
+      showSpeedTooltip(newSpeed);
+      _startSpeedGuard();
+    }
+  };
+
+  // Register on BOTH window and document with capture, plus bubble as fallback
+  window.addEventListener("keydown", handler, { capture: true });
+  document.addEventListener("keydown", handler, { capture: true });
+  // Also register non-capture on the video element directly if available
+  setInterval(() => {
+    const video = findScalerVideo();
+    if (video && !video._scalerSpeedAttached) {
+      video.addEventListener("keydown", (e) => {
+        handler(e);
+      });
+      video._scalerSpeedAttached = true;
+    }
+  }, 2000);
+
+  window._scalerSpeedHotkey = handler;
+}
+
+function teardownHotkeys() {
+  if (window._scalerSpeedHotkey) {
+    window.removeEventListener("keydown", window._scalerSpeedHotkey, { capture: true });
+    document.removeEventListener("keydown", window._scalerSpeedHotkey, { capture: true });
+    window._scalerSpeedHotkey = null;
+  }
+}
+
+// ─── Dropdown Observer ──────────────────────────
+
+let _dropdownParents = new WeakSet();
+
+function watchForDropdown() {
+  const obs = new MutationObserver(() => {
+    if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
+    injectExtraSpeedOptions();
+  });
+
+  obs.observe(document.body, { childList: true, subtree: true });
+
+  // Also watch specific dropdown containers when they appear
+  const containerFinder = new MutationObserver(() => {
+    const container = findDropdownContainer();
+    if (container && !_dropdownParents.has(container)) {
+      _dropdownParents.add(container);
+      const innerObs = new MutationObserver(() => {
+        setTimeout(injectExtraSpeedOptions, 100);
+      });
+      innerObs.observe(container, { childList: true, subtree: true, attributes: true });
+    }
+  });
+
+  containerFinder.observe(document.body, { childList: true, subtree: true });
+  window._scalerDropdownFinder = containerFinder;
+  window._scalerDropdownInjector = obs;
+}
+
+// ─── Init / Teardown ────────────────────────────
+
+function initVideoEndTime() {
+  if (window._endTimeObserver) return;
+
+  injectEndTimeOverlay();
+
+  const observer = new MutationObserver(() => {
+    injectEndTimeOverlay();
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+  window._endTimeObserver = observer;
+
+  // Speed-related features
+  // Inject responsive CSS
+  var _vetStyle = document.getElementById("scaler-vet-style");
+  if (!_vetStyle) {
+    _vetStyle = document.createElement("style");
+    _vetStyle.id = "scaler-vet-style";
+    _vetStyle.textContent =
+      "@media (max-width: 800px) { " +
+        "[" + VIDEO_END_TIME_ATTR + "] { display:none !important; } " +
+      "}";
+    document.head.appendChild(_vetStyle);
+  }
+
+  if (currentSettings && currentSettings["video-end-time-speed"]) {
+    watchForDropdown();
+    setTimeout(injectExtraSpeedOptions, 1500);
+    setTimeout(injectExtraSpeedOptions, 3000);
+    setupSpeedHotkeys();
+    _startSpeedGuard();
+  }
+}
+
 function removeEndTimeOverlay() {
+  // End time overlay
   const overlay = document.querySelector(`[${VIDEO_END_TIME_ATTR}]`);
   if (overlay) {
-    if (overlay._endTimeInterval) {
-      clearInterval(overlay._endTimeInterval);
-    }
+    if (overlay._endTimeInterval) clearInterval(overlay._endTimeInterval);
     if (overlay._rateChangeHandler && overlay._videoRef) {
       overlay._videoRef.removeEventListener(
         "ratechange",
@@ -295,79 +452,30 @@ function removeEndTimeOverlay() {
     overlay.remove();
   }
 
-  // Disconnect observer
+  // Observer
   if (window._endTimeObserver) {
     window._endTimeObserver.disconnect();
     window._endTimeObserver = null;
   }
 
-  // Remove hotkey listener
-  if (window._endTimeHotkeyHandler) {
-    document.removeEventListener("keydown", window._endTimeHotkeyHandler);
-    window._endTimeHotkeyHandler = null;
+  // Hotkeys
+  teardownHotkeys();
+
+  // Speed guardian
+  _stopSpeedGuard();
+
+  // Dropdown injected items
+  document.querySelectorAll(`.${SCALER_EXTRA_ITEM}`).forEach((el) => el.remove());
+
+  // Dropdown observers
+  if (window._scalerDropdownFinder) {
+    window._scalerDropdownFinder.disconnect();
+    window._scalerDropdownFinder = null;
   }
-}
+  if (window._scalerDropdownInjector) {
+    window._scalerDropdownInjector.disconnect();
+    window._scalerDropdownInjector = null;
+  }
 
-/**
- * Set up keyboard shortcuts for speed control.
- * Shift+. (>) = speed up    Shift+, (<) = slow down
- */
-function setupSpeedHotkeys() {
-  if (window._endTimeHotkeyHandler) return; // already set up
-
-  const handler = (e) => {
-    // Only when speed feature is enabled
-    if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
-
-    // Only when a video is present on the page
-    const video = findScalerVideo();
-    if (!video) return;
-
-    // Shift + . (period) = speed up
-    if (e.shiftKey && e.key === ".") {
-      e.preventDefault();
-      const current = video.playbackRate || 1;
-      const newSpeed = nextSpeedPreset(current);
-      applyPlaybackSpeed(video, newSpeed);
-      syncSpeedInput(newSpeed);
-      localStorage.setItem(CUSTOM_SPEED_KEY, newSpeed);
-      showSpeedTooltip(newSpeed);
-    }
-
-    // Shift + , (comma) = slow down
-    if (e.shiftKey && e.key === ",") {
-      e.preventDefault();
-      const current = video.playbackRate || 1;
-      const newSpeed = prevSpeedPreset(current);
-      applyPlaybackSpeed(video, newSpeed);
-      syncSpeedInput(newSpeed);
-      localStorage.setItem(CUSTOM_SPEED_KEY, newSpeed);
-      showSpeedTooltip(newSpeed);
-    }
-  };
-
-  document.addEventListener("keydown", handler);
-  window._endTimeHotkeyHandler = handler;
-}
-
-/**
- * Initialize the video end time feature.
- */
-function initVideoEndTime() {
-  // Don't double-init
-  if (window._endTimeObserver) return;
-
-  // Try injecting immediately (player might already be in DOM)
-  injectEndTimeOverlay();
-
-  // Watch for DOM changes (SPA navigation, player appearing)
-  const observer = new MutationObserver(() => {
-    injectEndTimeOverlay();
-  });
-
-  observer.observe(document.body, { childList: true, subtree: true });
-  window._endTimeObserver = observer;
-
-  // Set up speed hotkeys
-  setupSpeedHotkeys();
+  _lastCustomSpeed = null;
 }

--- a/extension-main/content/features/videoEndTime.js
+++ b/extension-main/content/features/videoEndTime.js
@@ -1,28 +1,30 @@
 // ============================================
 // features/videoEndTime.js
-// Video end time display + extended speed dropdown + hotkeys
+// Video end time display + custom speed panel + hotkeys
 //
-// Shows "Ends at: HH:MM" on Scaler's video player, styled to match
-// the native control bar. Extends the existing playback speed
-// dropdown with values beyond 2x (up to 16x). Keyboard shortcuts
-// allow quick speed changes (Shift+. speed up, Shift+, slow down).
+// Shows "Ends at: HH:MM" on Scaler's video player.
+// Replaces the native speed dropdown with a custom
+// speed panel (slider + speed dial buttons).
+// Keyboard shortcuts: Shift+. / Shift+, for ±0.1x.
 // ============================================
 
 const VIDEO_END_TIME_ATTR = "data-scaler-end-time";
-const SCALER_EXTRA_ITEM = "scaler-extra-speed";
-const SCALER_SPEED_ATTR = "data-scaler-custom-speed";
-
+const SPEED_PANEL_ID = "scaler-speed-panel";
 const CUSTOM_SPEED_KEY = "scaler-custom-speed";
-const EXTRA_SPEEDS = [2.5, 3, 4, 6, 8, 12, 16];
-const SPEED_PRESETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 12, 16];
+const SPEED_TIP_ID = "scaler-speed-tip";
 
-// Store the last custom speed so we can re-apply it if Scaler resets it
+// Speed dial presets
+const SPEED_DIAL = [
+  0.5, 1, 1.25, 1.5, 1.75, 2, 2.15, 2.5, 2.75,
+  3, 3.5, 4, 6, 8, 12, 16,
+];
+
 let _lastCustomSpeed = null;
 let _speedGuardInterval = null;
 
-// ─── Helpers ──────────────────────────────────────
+// ─── DOM helpers ────────────────────────────────
 
-function findScalerVideo() {
+function findVideo() {
   return (
     document.querySelector(".vp-video") ||
     document.querySelector("video.vp-video") ||
@@ -35,242 +37,364 @@ function findTimeDisplay() {
   return document.querySelector(".vp-controls__duration");
 }
 
-function findSpeedTitle() {
-  return document.querySelector(".vp-playback-title");
-}
-
 function findSpeedButton() {
   return document.querySelector(
-    "[data-cy='video-player-controls-playback-rate-button'], .vp-dropdown"
+    ".vp-playback-title, " +
+    "[data-cy='video-player-controls-playback-rate-button']"
   );
 }
 
-function findDropdownContainer() {
+function findSpeedDropdownContainer() {
   const btn = findSpeedButton();
-  return btn ? btn.closest(".dropdown") : null;
+  return btn ? btn.closest(".dropdown, .vp-controls__control") : null;
 }
 
 function formatEndTime(date) {
-  return date.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-// ─── Speed Application ──────────────────────────
+// ─── Speed Apply ────────────────────────────────
 
-function applyPlaybackSpeed(video, speed) {
-  if (!video) return false;
+function applySpeed(video, speed) {
+  if (!video) return;
   const rate = Math.max(0.1, Math.min(16, parseFloat(speed) || 1));
   video.playbackRate = rate;
   _lastCustomSpeed = rate;
-
-  // Update dropdown title
-  const title = findSpeedTitle();
-  if (title) {
-    const display = rate === Math.round(rate) ? rate + "" : rate.toFixed(2);
-    title.textContent = display + "x";
-  }
-
   localStorage.setItem(CUSTOM_SPEED_KEY, String(rate));
+  updateSpeedButtonLabel(rate);
   return rate;
 }
 
-// ─── Speed Guardian ────────────────────────────
-// Scaler's player may reset playbackRate on various events (seeking,
-// source change, fullscreen toggle, etc.).  This runs a tick every
-// 600ms and re-applies the custom speed if the player changed it.
+function updateSpeedButtonLabel(rate) {
+  const label = rate === Math.round(rate) ? rate + "" : rate.toFixed(2);
+  const title = findSpeedButton();
+  if (title) title.textContent = label + "x";
+}
 
-function _startSpeedGuard() {
+// ─── Speed Guardian ─────────────────────────────
+
+function startSpeedGuard() {
   if (_speedGuardInterval) return;
   _speedGuardInterval = setInterval(() => {
     if (!_lastCustomSpeed) return;
-    const video = findScalerVideo();
-    if (!video || !video.duration) return;
-    // If the player's rate differs from ours and it's outside our range
+    const video = findVideo();
+    if (!video) return;
     if (Math.abs(video.playbackRate - _lastCustomSpeed) > 0.01) {
-      // Only re-apply if our speed is >2x (native speeds are handled by Scaler)
-      // or if it's clearly a reset (back to 1x while we were at e.g. 1.5x)
-      const isNative = video.playbackRate <= 2 && _lastCustomSpeed <= 2;
-      if (!isNative) {
+      // Only re-apply if it looks like a reset (rate changed to a close value
+      // that's not our speed, or back to 1x while we were faster)
+      if (video.playbackRate <= 2 || _lastCustomSpeed > 2) {
         video.playbackRate = _lastCustomSpeed;
       }
     }
   }, 600);
 }
 
-function _stopSpeedGuard() {
+function stopSpeedGuard() {
   if (_speedGuardInterval) {
     clearInterval(_speedGuardInterval);
     _speedGuardInterval = null;
   }
 }
 
-// ─── End Time Overlay ────────────────────────────
+// ─── End Time Overlay ───────────────────────────
 
-function injectEndTimeOverlay() {
-  const video = findScalerVideo();
-  const timeDisplay = findTimeDisplay();
-  if (!video || !timeDisplay) return;
+function injectEndTime() {
+  const video = findVideo();
+  const td = findTimeDisplay();
+  if (!video || !td) return;
   if (document.querySelector(`[${VIDEO_END_TIME_ATTR}]`)) return;
 
-  // Restore saved speed
   const saved = parseFloat(localStorage.getItem(CUSTOM_SPEED_KEY));
   if (saved && saved > 0 && Math.abs(saved - video.playbackRate) > 0.01) {
-    applyPlaybackSpeed(video, saved);
+    applySpeed(video, saved);
   }
 
-  const container = document.createElement("div");
-  container.setAttribute(VIDEO_END_TIME_ATTR, "true");
-  container.style.display = "flex";
-  container.style.alignItems = "center";
-  container.style.gap = "8px";
-  container.style.flexShrink = "0";
+  const wrap = document.createElement("div");
+  wrap.setAttribute(VIDEO_END_TIME_ATTR, "true");
+  wrap.style.cssText = "display:flex;align-items:center;gap:8px;flex-shrink:0";
 
-  const endTimeDiv = document.createElement("div");
-  endTimeDiv.className = "vp-controls__duration";
-  endTimeDiv.style.whiteSpace = "nowrap";
-  endTimeDiv.style.fontSize = "inherit";
-  container.appendChild(endTimeDiv);
+  const el = document.createElement("div");
+  el.className = "vp-controls__duration";
+  el.style.whiteSpace = "nowrap";
+  wrap.appendChild(el);
 
-  // Insert after the native duration
-  timeDisplay.parentNode.insertBefore(container, timeDisplay.nextSibling);
+  td.parentNode.insertBefore(wrap, td.nextSibling);
 
-  function updateEndTime() {
+  function tick() {
     if (!video || !video.duration || video.duration === Infinity) return;
-    const remaining =
-      (video.duration - video.currentTime) / (video.playbackRate || 1);
-    const endTime = new Date(Date.now() + remaining * 1000);
-    endTimeDiv.textContent = `Ends at: ${formatEndTime(endTime)}`;
+    const rem = (video.duration - video.currentTime) / (video.playbackRate || 1);
+    el.textContent = "Ends at: " + formatEndTime(new Date(Date.now() + rem * 1000));
   }
 
-  updateEndTime();
-  const intervalId = setInterval(updateEndTime, 1000);
-  container._endTimeInterval = intervalId;
-  container._videoRef = video;
+  tick();
+  const iv = setInterval(tick, 1000);
+  wrap._iv = iv;
 
-  const rateHandler = () => updateEndTime();
-  video.addEventListener("ratechange", rateHandler);
-  container._rateChangeHandler = rateHandler;
+  const rh = () => tick();
+  video.addEventListener("ratechange", rh);
+  wrap._rh = rh;
+  wrap._vid = video;
 }
 
-// ─── Speed Dropdown Extension ───────────────────
+// ─── Speed Panel (slider + speed dial) ──────────
 
-/**
- * Find the actual dropdown menu that contains speed options.
- * Scaler's dropdown may vary in structure, so we try multiple strategies.
- */
-function findSpeedMenu() {
-  const container = findDropdownContainer();
-  if (!container) return null;
+function buildSpeedPanel() {
+  // Remove existing panel if any
+  const old = document.getElementById(SPEED_PANEL_ID);
+  if (old) old.remove();
 
-  // Strategy 1: standard dropdown menu class
-  let menu = container.querySelector(
-    ".dropdown__items, .dropdown__menu, [role='menu'], .vp-dropdown-items, .vp-playback-menu"
-  );
-  if (menu) return menu;
+  const panel = document.createElement("div");
+  panel.id = SPEED_PANEL_ID;
+  panel.style.cssText = `
+    position:fixed; z-index:99999;
+    background:#1a1a2e; border:1px solid rgba(255,255,255,0.12);
+    border-radius:12px; padding:16px 20px 18px;
+    box-shadow:0 8px 32px rgba(0,0,0,0.6);
+    min-width:280px;
+    font-family:inherit;
+  `;
 
-  // Strategy 2: look for a sibling/child div that becomes visible when dropdown is open
-  const allChildren = container.querySelectorAll(":scope > div, :scope > ul, :scope > section");
-  for (const child of allChildren) {
-    if (child !== findSpeedButton() && child.offsetParent !== null) {
-      const items = child.querySelectorAll("a, button, div[role='menuitem'], .dropdown__item");
-      if (items.length >= 3) return child; // looks like a menu with items
+  // ── Current speed display ──
+  const currentRate = findVideo()?.playbackRate || 1;
+
+  const header = document.createElement("div");
+  header.style.cssText =
+    "display:flex;justify-content:space-between;align-items:center;margin-bottom:10px";
+
+  const title = document.createElement("span");
+  title.textContent = "Playback Speed";
+  title.style.cssText = "color:rgba(255,255,255,0.7);font-size:13px;font-weight:500";
+
+  const rateVal = document.createElement("span");
+  rateVal.id = "scaler-speed-value";
+  const disp = currentRate === Math.round(currentRate) ? currentRate + "" : currentRate.toFixed(2);
+  rateVal.textContent = disp + "x";
+  rateVal.style.cssText = "color:#fff;font-size:18px;font-weight:700";
+
+  header.appendChild(title);
+  header.appendChild(rateVal);
+  panel.appendChild(header);
+
+  // ── Slider ──
+  const sliderWrap = document.createElement("div");
+  sliderWrap.style.cssText = "margin-bottom:14px";
+
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.min = "0.1";
+  slider.max = "16";
+  slider.step = "0.1";
+  slider.value = String(currentRate);
+  slider.style.cssText = `
+    width:100%; height:4px; -webkit-appearance:none; appearance:none;
+    background:linear-gradient(to right, #6366f1 0%, #6366f1 50%, rgba(255,255,255,0.15) 50%);
+    border-radius:2px; outline:none; cursor:pointer;
+  `;
+
+  // Slider thumb styling
+  const thumbStyle = document.createElement("style");
+  thumbStyle.textContent = `
+    #${SPEED_PANEL_ID} input[type=range]::-webkit-slider-thumb {
+      -webkit-appearance:none; appearance:none;
+      width:16px; height:16px; border-radius:50%;
+      background:#6366f1; border:2px solid #fff;
+      cursor:pointer; box-shadow:0 2px 6px rgba(0,0,0,0.3);
     }
-  }
-
-  // Strategy 3: the menu might be outside the .dropdown container but attached to body
-  // Look for visible menus
-  const visibleMenus = document.querySelectorAll(
-    ".dropdown__items:not([hidden]), .dropdown__menu:not([hidden]), [role='menu']:not([hidden])"
-  );
-  for (const m of visibleMenus) {
-    if (m.textContent.includes("1x") && m.textContent.includes("2x")) {
-      return m;
+    #${SPEED_PANEL_ID} input[type=range]::-moz-range-thumb {
+      width:16px; height:16px; border-radius:50%;
+      background:#6366f1; border:2px solid #fff;
+      cursor:pointer;
     }
-  }
+  `;
+  document.head.appendChild(thumbStyle);
 
-  return null;
-}
+  // Slider gradient update on input
+  const updateSliderBG = () => {
+    const pct = ((slider.value - 0.1) / (16 - 0.1)) * 100;
+    slider.style.background =
+      `linear-gradient(to right, #6366f1 0%, #6366f1 ${pct}%, rgba(255,255,255,0.15) ${pct}%)`;
+  };
 
-function injectExtraSpeedOptions() {
-  if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
+  slider.addEventListener("input", () => {
+    const val = parseFloat(slider.value);
+    const video = findVideo();
+    if (video) applySpeed(video, val);
+    const disp2 = val === Math.round(val) ? val + "" : val.toFixed(2);
+    document.getElementById("scaler-speed-value").textContent = disp2 + "x";
+    updateSliderBG();
+    highlightActiveDial(val);
+  });
 
-  const menu = findSpeedMenu();
-  if (!menu) return;
+  sliderWrap.appendChild(slider);
+  panel.appendChild(sliderWrap);
 
-  // Already injected?
-  if (menu.querySelector(`.${SCALER_EXTRA_ITEM}`)) return;
+  // ── Speed dial buttons ──
+  const dialGrid = document.createElement("div");
+  dialGrid.style.cssText =
+    "display:flex;flex-wrap:wrap;gap:6px;justify-content:center";
 
-  // Find last native item (look for anything containing a speed value)
-  const allItems = menu.querySelectorAll(
-    "[role='menuitem'], .dropdown__item, a, button, div"
-  );
-  let lastItem = null;
-  for (const item of allItems) {
-    if (item.closest(`.${SCALER_EXTRA_ITEM}`)) continue; // skip our own
-    const text = item.textContent.trim();
-    if (/^\d+(\.\d+)?x$/.test(text)) {
-      lastItem = item;
+  SPEED_DIAL.forEach((s) => {
+    const btn = document.createElement("button");
+    btn.dataset.speed = String(s);
+    const label = s === Math.round(s) ? s + "" : s.toFixed(2);
+    btn.textContent = label + "x";
+    btn.style.cssText = `
+      padding:5px 10px; border-radius:6px; border:1px solid rgba(255,255,255,0.1);
+      background:rgba(255,255,255,0.05); color:rgba(255,255,255,0.85);
+      font-size:12px; cursor:pointer; transition:all 0.15s;
+      font-family:inherit;
+    `;
+
+    if (Math.abs(s - currentRate) < 0.01) {
+      btn.style.background = "#6366f1";
+      btn.style.borderColor = "#6366f1";
+      btn.style.color = "#fff";
     }
-  }
 
-  if (!lastItem) return;
-
-  // Divider
-  const divider = document.createElement("div");
-  divider.className = `${SCALER_EXTRA_ITEM} dropdown__divider`;
-  divider.style.cssText =
-    "height:1px;background:rgba(255,255,255,0.15);margin:4px 12px;";
-  lastItem.parentNode.insertBefore(divider, lastItem.nextSibling);
-
-  // Extra speed items (insert after divider)
-  EXTRA_SPEEDS.forEach((speed) => {
-    const item = document.createElement("div");
-    item.className = `dropdown__item ${SCALER_EXTRA_ITEM}`;
-    item.setAttribute("role", "menuitem");
-    item.setAttribute(SCALER_SPEED_ATTR, String(speed));
-    item.textContent = speed + "x";
-    item.style.cursor = "pointer";
-
-    item.addEventListener("mousedown", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const video = findScalerVideo();
-      if (video) {
-        applyPlaybackSpeed(video, speed);
-        showSpeedTooltip(speed);
-        _startSpeedGuard();
+    btn.addEventListener("mouseenter", () => {
+      if (!btn.classList.contains("active")) {
+        btn.style.background = "rgba(255,255,255,0.12)";
       }
-      dismissDropdown();
+    });
+    btn.addEventListener("mouseleave", () => {
+      if (!btn.classList.contains("active")) {
+        btn.style.background = "rgba(255,255,255,0.05)";
+      }
     });
 
-    divider.parentNode.insertBefore(item, divider.nextSibling);
+    btn.addEventListener("click", () => {
+      const rate = parseFloat(btn.dataset.speed);
+      const video = findVideo();
+      if (video) {
+        applySpeed(video, rate);
+        slider.value = String(rate);
+        updateSliderBG();
+        const d = rate === Math.round(rate) ? rate + "" : rate.toFixed(2);
+        document.getElementById("scaler-speed-value").textContent = d + "x";
+        highlightActiveDial(rate);
+      }
+      closePanel();
+    });
+
+    dialGrid.appendChild(btn);
   });
+
+  panel.appendChild(dialGrid);
+
+  // ── Keyboard hint ──
+  const hint = document.createElement("div");
+  hint.style.cssText =
+    "color:rgba(255,255,255,0.35);font-size:11px;text-align:center;margin-top:10px";
+  hint.textContent = "Shift + , / .  to fine-tune ±0.1";
+  panel.appendChild(hint);
+
+  document.body.appendChild(panel);
+  positionPanel(panel);
+
+  // Active dial highlighter
+  function highlightActiveDial(rate) {
+    dialGrid.querySelectorAll("button").forEach((b) => {
+      const sv = parseFloat(b.dataset.speed);
+      b.classList.remove("active");
+      b.style.background = Math.abs(sv - rate) < 0.01
+        ? "#6366f1"
+        : "rgba(255,255,255,0.05)";
+      b.style.borderColor = Math.abs(sv - rate) < 0.01
+        ? "#6366f1"
+        : "rgba(255,255,255,0.1)";
+      b.style.color = Math.abs(sv - rate) < 0.01 ? "#fff" : "rgba(255,255,255,0.85)";
+    });
+  }
+
+  return panel;
 }
 
-/**
- * Try to dismiss the open speed dropdown by dispatching Escape.
- */
-function dismissDropdown() {
-  // Dispatch Escape in both capture and bubble
-  document.dispatchEvent(new KeyboardEvent("keydown", {
-    key: "Escape",
-    code: "Escape",
-    bubbles: true,
-    cancelable: true,
-  }));
+function positionPanel(panel) {
+  const btn = findSpeedButton();
+  if (!btn) return;
+  const rect = btn.getBoundingClientRect();
+  const panelW = panel.offsetWidth || 280;
+
+  // Position above the button, centered
+  let left = rect.left + rect.width / 2 - panelW / 2;
+  let top = rect.top - 12 - panel.offsetHeight;
+
+  // Clamp to viewport
+  if (left < 8) left = 8;
+  if (left + panelW > window.innerWidth - 8) {
+    left = window.innerWidth - panelW - 8;
+  }
+  if (top < 8) {
+    // If not enough room above, place below
+    top = rect.bottom + 12;
+  }
+
+  panel.style.left = left + "px";
+  panel.style.top = top + "px";
 }
 
-// ─── Tooltip ─────────────────────────────────────
+function closePanel() {
+  const p = document.getElementById(SPEED_PANEL_ID);
+  if (p) p.remove();
+}
 
-function showSpeedTooltip(speed) {
-  const existing = document.getElementById("scaler-speed-tip");
-  if (existing) existing.remove();
+// ─── Intercept Speed Button ─────────────────────
+
+let _speedButtonIntercepted = false;
+
+function interceptSpeedButton() {
+  if (_speedButtonIntercepted) return;
+
+  const container = findSpeedDropdownContainer();
+  if (!container) {
+    // Try again later
+    setTimeout(interceptSpeedButton, 1000);
+    return;
+  }
+
+  // Intercept clicks on the speed button
+  container.addEventListener(
+    "mousedown",
+    (e) => {
+      // Check if click is on or inside the speed button area
+      const btn = findSpeedButton();
+      if (!btn) return;
+      if (!btn.contains(e.target) && !container.querySelector(".vp-playback-title")?.contains(e.target)) {
+        return;
+      }
+
+      // Only intercept if speed feature is enabled
+      if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+
+      // Toggle panel
+      const existing = document.getElementById(SPEED_PANEL_ID);
+      if (existing) {
+        closePanel();
+        return;
+      }
+
+      buildSpeedPanel();
+    },
+    { capture: true }
+  );
+
+  _speedButtonIntercepted = true;
+}
+
+// ─── Tooltip ────────────────────────────────────
+
+function showTooltip(speed) {
+  const old = document.getElementById(SPEED_TIP_ID);
+  if (old) old.remove();
 
   const tip = document.createElement("div");
-  tip.id = "scaler-speed-tip";
-  tip.textContent = speed + "x";
+  tip.id = SPEED_TIP_ID;
+  const label = speed === Math.round(speed) ? speed + "" : speed.toFixed(2);
+  tip.textContent = label + "x";
   tip.style.cssText = `
     position:fixed; top:50%; left:50%;
     transform:translate(-50%,-50%);
@@ -281,16 +405,14 @@ function showSpeedTooltip(speed) {
     animation:speed-tip-fade 1.2s ease-out forwards;
   `;
 
-  if (!document.getElementById("speed-tip-keyframes")) {
+  if (!document.getElementById("speed-tip-kf")) {
     const s = document.createElement("style");
-    s.id = "speed-tip-keyframes";
-    s.textContent = `
-      @keyframes speed-tip-fade {
-        0% { opacity:1; transform:translate(-50%,-50%) scale(1); }
-        60% { opacity:1; transform:translate(-50%,-50%) scale(1.05); }
-        100% { opacity:0; transform:translate(-50%,-50%) scale(0.9); }
-      }
-    `;
+    s.id = "speed-tip-kf";
+    s.textContent = `@keyframes speed-tip-fade {
+      0%{opacity:1;transform:translate(-50%,-50%) scale(1)}
+      60%{opacity:1;transform:translate(-50%,-50%) scale(1.05)}
+      100%{opacity:0;transform:translate(-50%,-50%) scale(0.9)}
+    }`;
     document.head.appendChild(s);
   }
 
@@ -298,184 +420,109 @@ function showSpeedTooltip(speed) {
   setTimeout(() => tip.remove(), 1300);
 }
 
-// ─── Hotkeys ─────────────────────────────────────
+// ─── Hotkeys (0.1x step) ────────────────────────
 
-function nextSpeed(current) {
-  for (const s of SPEED_PRESETS) {
-    if (s > current + 0.01) return s;
-  }
-  return SPEED_PRESETS[SPEED_PRESETS.length - 1];
-}
-
-function prevSpeed(current) {
-  for (let i = SPEED_PRESETS.length - 1; i >= 0; i--) {
-    if (SPEED_PRESETS[i] < current - 0.01) return SPEED_PRESETS[i];
-  }
-  return SPEED_PRESETS[0];
-}
-
-function setupSpeedHotkeys() {
-  if (window._scalerSpeedHotkey) return;
+function setupHotkeys() {
+  if (window._scalerHK) return;
 
   const handler = (e) => {
     if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
-    const video = findScalerVideo();
+    const video = findVideo();
     if (!video || !video.duration) return;
 
-    let handled = false;
     let newSpeed = null;
 
-    // Shift + Period (>) = speed up
     if (e.shiftKey && (e.code === "Period" || e.key === ">" || e.key === ".")) {
-      const cur = video.playbackRate || 1;
-      newSpeed = nextSpeed(cur);
-      handled = true;
+      newSpeed = Math.min(16, (video.playbackRate || 1) + 0.1);
+    } else if (e.shiftKey && (e.code === "Comma" || e.key === "<" || e.key === ",")) {
+      newSpeed = Math.max(0.1, (video.playbackRate || 1) - 0.1);
     }
 
-    // Shift + Comma (<) = slow down
-    if (e.shiftKey && (e.code === "Comma" || e.key === "<" || e.key === ",")) {
-      const cur = video.playbackRate || 1;
-      newSpeed = prevSpeed(cur);
-      handled = true;
-    }
-
-    if (handled && newSpeed !== null) {
+    if (newSpeed !== null) {
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
-      applyPlaybackSpeed(video, newSpeed);
-      showSpeedTooltip(newSpeed);
-      _startSpeedGuard();
+      applySpeed(video, newSpeed);
+      showTooltip(newSpeed);
+      startSpeedGuard();
+      // Round to 1 decimal for display
+      const rounded = Math.round(newSpeed * 10) / 10;
+      updateSpeedButtonLabel(rounded);
     }
   };
 
-  // Register on BOTH window and document with capture, plus bubble as fallback
   window.addEventListener("keydown", handler, { capture: true });
   document.addEventListener("keydown", handler, { capture: true });
-  // Also register non-capture on the video element directly if available
-  setInterval(() => {
-    const video = findScalerVideo();
-    if (video && !video._scalerSpeedAttached) {
-      video.addEventListener("keydown", (e) => {
-        handler(e);
-      });
-      video._scalerSpeedAttached = true;
-    }
-  }, 2000);
-
-  window._scalerSpeedHotkey = handler;
+  window._scalerHK = handler;
 }
 
 function teardownHotkeys() {
-  if (window._scalerSpeedHotkey) {
-    window.removeEventListener("keydown", window._scalerSpeedHotkey, { capture: true });
-    document.removeEventListener("keydown", window._scalerSpeedHotkey, { capture: true });
-    window._scalerSpeedHotkey = null;
+  if (window._scalerHK) {
+    window.removeEventListener("keydown", window._scalerHK, { capture: true });
+    document.removeEventListener("keydown", window._scalerHK, { capture: true });
+    window._scalerHK = null;
   }
-}
-
-// ─── Dropdown Observer ──────────────────────────
-
-let _dropdownParents = new WeakSet();
-
-function watchForDropdown() {
-  const obs = new MutationObserver(() => {
-    if (!currentSettings || !currentSettings["video-end-time-speed"]) return;
-    injectExtraSpeedOptions();
-  });
-
-  obs.observe(document.body, { childList: true, subtree: true });
-
-  // Also watch specific dropdown containers when they appear
-  const containerFinder = new MutationObserver(() => {
-    const container = findDropdownContainer();
-    if (container && !_dropdownParents.has(container)) {
-      _dropdownParents.add(container);
-      const innerObs = new MutationObserver(() => {
-        setTimeout(injectExtraSpeedOptions, 100);
-      });
-      innerObs.observe(container, { childList: true, subtree: true, attributes: true });
-    }
-  });
-
-  containerFinder.observe(document.body, { childList: true, subtree: true });
-  window._scalerDropdownFinder = containerFinder;
-  window._scalerDropdownInjector = obs;
 }
 
 // ─── Init / Teardown ────────────────────────────
 
 function initVideoEndTime() {
-  if (window._endTimeObserver) return;
+  if (window._endTimeObs) return;
 
-  injectEndTimeOverlay();
-
-  const observer = new MutationObserver(() => {
-    injectEndTimeOverlay();
-  });
-  observer.observe(document.body, { childList: true, subtree: true });
-  window._endTimeObserver = observer;
-
-  // Speed-related features
-  // Inject responsive CSS
-  var _vetStyle = document.getElementById("scaler-vet-style");
-  if (!_vetStyle) {
-    _vetStyle = document.createElement("style");
-    _vetStyle.id = "scaler-vet-style";
-    _vetStyle.textContent =
-      "@media (max-width: 800px) { " +
-        "[" + VIDEO_END_TIME_ATTR + "] { display:none !important; } " +
-      "}";
-    document.head.appendChild(_vetStyle);
+  // Responsive CSS
+  if (!document.getElementById("scaler-vet-css")) {
+    const s = document.createElement("style");
+    s.id = "scaler-vet-css";
+    s.textContent =
+      "@media(max-width:800px){[" + VIDEO_END_TIME_ATTR + "]{display:none!important}}";
+    document.head.appendChild(s);
   }
+
+  injectEndTime();
+
+  const obs = new MutationObserver(() => injectEndTime());
+  obs.observe(document.body, { childList: true, subtree: true });
+  window._endTimeObs = obs;
 
   if (currentSettings && currentSettings["video-end-time-speed"]) {
-    watchForDropdown();
-    setTimeout(injectExtraSpeedOptions, 1500);
-    setTimeout(injectExtraSpeedOptions, 3000);
-    setupSpeedHotkeys();
-    _startSpeedGuard();
+    interceptSpeedButton();
+    setTimeout(interceptSpeedButton, 2000);
+    setupHotkeys();
+    startSpeedGuard();
   }
+
+  // Close panel on Escape / click outside
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closePanel();
+  });
+  document.addEventListener("mousedown", (e) => {
+    const p = document.getElementById(SPEED_PANEL_ID);
+    if (p && !p.contains(e.target)) {
+      const btn = findSpeedButton();
+      if (!btn || !btn.contains(e.target)) {
+        closePanel();
+      }
+    }
+  });
 }
 
 function removeEndTimeOverlay() {
   // End time overlay
-  const overlay = document.querySelector(`[${VIDEO_END_TIME_ATTR}]`);
-  if (overlay) {
-    if (overlay._endTimeInterval) clearInterval(overlay._endTimeInterval);
-    if (overlay._rateChangeHandler && overlay._videoRef) {
-      overlay._videoRef.removeEventListener(
-        "ratechange",
-        overlay._rateChangeHandler
-      );
-    }
-    overlay.remove();
+  const wrap = document.querySelector(`[${VIDEO_END_TIME_ATTR}]`);
+  if (wrap) {
+    if (wrap._iv) clearInterval(wrap._iv);
+    if (wrap._rh && wrap._vid) wrap._vid.removeEventListener("ratechange", wrap._rh);
+    wrap.remove();
   }
 
-  // Observer
-  if (window._endTimeObserver) {
-    window._endTimeObserver.disconnect();
-    window._endTimeObserver = null;
+  closePanel();
+  if (window._endTimeObs) {
+    window._endTimeObs.disconnect();
+    window._endTimeObs = null;
   }
 
-  // Hotkeys
   teardownHotkeys();
-
-  // Speed guardian
-  _stopSpeedGuard();
-
-  // Dropdown injected items
-  document.querySelectorAll(`.${SCALER_EXTRA_ITEM}`).forEach((el) => el.remove());
-
-  // Dropdown observers
-  if (window._scalerDropdownFinder) {
-    window._scalerDropdownFinder.disconnect();
-    window._scalerDropdownFinder = null;
-  }
-  if (window._scalerDropdownInjector) {
-    window._scalerDropdownInjector.disconnect();
-    window._scalerDropdownInjector = null;
-  }
-
+  stopSpeedGuard();
   _lastCustomSpeed = null;
+  _speedButtonIntercepted = false;
 }

--- a/extension-main/manifest.json
+++ b/extension-main/manifest.json
@@ -79,6 +79,7 @@
         "content/features/spotlightSearch.js",
         "content/features/liveStreamRecorder/liveStreamRecorder.js",
         "content/features/themeManager.js",
+        "content/features/videoEndTime.js",
         "content/content.js"
       ],
       "css": [

--- a/extension-main/popup.html
+++ b/extension-main/popup.html
@@ -171,8 +171,8 @@
                 >
                   <span class="toggle-title">⏱️ Video End Time</span>
                   <span class="toggle-desc"
-                    >Show when the lecture video will finish. Includes custom
-                    speed control beyond 2x.</span
+                    >Show when the lecture video will finish, extends the
+                    speed dropdown beyond 2x.</span
                   >
                 </label>
 
@@ -189,7 +189,7 @@
                         >⚡ Speed Override &amp; Hotkeys</span
                       >
                       <span class="toggle-desc" style="font-size: 10px"
-                        >Custom speed input + Shift+, / Shift+. hotkeys</span
+                        >Extends speed dropdown + Shift+, / Shift+. hotkeys</span
                       >
                     </div>
                     <div class="toggle-switch">

--- a/extension-main/popup.html
+++ b/extension-main/popup.html
@@ -154,6 +154,70 @@
               </div>
             </label>
 
+            <!-- Video End Time toggle -->
+            <div
+              class="toggle-item highlight"
+              style="align-items: flex-start; cursor: default"
+            >
+              <div class="toggle-info" style="gap: 10px">
+                <label
+                  for="toggle-video-end-time"
+                  style="
+                    cursor: pointer;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 2px;
+                  "
+                >
+                  <span class="toggle-title">⏱️ Video End Time</span>
+                  <span class="toggle-desc"
+                    >Show when the lecture video will finish. Includes custom
+                    speed control beyond 2x.</span
+                  >
+                </label>
+
+                <div
+                  id="video-end-time-options"
+                  style="display: none"
+                >
+                  <label
+                    class="toggle-item highlight"
+                    style="padding: 6px 8px; border-radius: 6px; cursor: pointer"
+                  >
+                    <div class="toggle-info">
+                      <span class="toggle-title" style="font-size: 12px"
+                        >⚡ Speed Override &amp; Hotkeys</span
+                      >
+                      <span class="toggle-desc" style="font-size: 10px"
+                        >Custom speed input + Shift+, / Shift+. hotkeys</span
+                      >
+                    </div>
+                    <div class="toggle-switch">
+                      <input
+                        type="checkbox"
+                        id="toggle-video-end-time-speed"
+                        checked
+                      />
+                      <span class="slider"></span>
+                    </div>
+                  </label>
+                </div>
+              </div>
+
+              <label
+                class="toggle-switch"
+                for="toggle-video-end-time"
+                style="margin-top: 4px; cursor: pointer"
+              >
+                <input
+                  type="checkbox"
+                  id="toggle-video-end-time"
+                  checked
+                />
+                <span class="slider"></span>
+              </label>
+            </div>
+
             <label class="toggle-item highlight">
               <div class="toggle-info">
                 <span class="toggle-title">🔗 LeetCode Link</span>

--- a/extension-main/popup.html
+++ b/extension-main/popup.html
@@ -189,7 +189,7 @@
                         >⚡ Speed Override &amp; Hotkeys</span
                       >
                       <span class="toggle-desc" style="font-size: 10px"
-                        >Extends speed dropdown + Shift+, / Shift+. hotkeys</span
+                        >Custom speed slider + Shift+, / Shift+. hotkeys ±0.1x</span
                       >
                     </div>
                     <div class="toggle-switch">

--- a/extension-main/popup.js
+++ b/extension-main/popup.js
@@ -53,6 +53,10 @@ const DEFAULT_SETTINGS = {
   // Spotlight Search
   "spotlight-search": true,
 
+  // Video End Time
+  "video-end-time": true,
+  "video-end-time-speed": true,
+
   // Appearance — site-wide theme ("off" = native Scaler look)
   theme: "off",
 };
@@ -90,6 +94,8 @@ const TOGGLE_MAP = {
   "toggle-calendar-sync": "calendar-sync",
   "toggle-contest-leaderboard": "contest-leaderboard",
   "toggle-spotlight-search": "spotlight-search",
+  "toggle-video-end-time": "video-end-time",
+  "toggle-video-end-time-speed": "video-end-time-speed",
 };
 
 // Current settings state
@@ -230,6 +236,7 @@ async function handleToggleChange(toggleId, settingKey) {
       "video-downloader",
       "contest-leaderboard",
       "spotlight-search",
+      "video-end-time",
     ].includes(settingKey);
     if (isEnhancement) {
       showToast(newValue ? "Enabled ✓" : "Disabled ✓", "success");
@@ -259,6 +266,7 @@ function _syncSubOptions(settingKey, visible) {
   const panelIds = {
     "practice-mode": "practice-mode-options",
     "calendar-sync": "calendar-sync-options",
+    "video-end-time": "video-end-time-options",
   };
 
   const panelId = panelIds[settingKey];


### PR DESCRIPTION
## Summary

Adds a **Video End Time** feature that shows when a Scaler lecture video will finish, and **replaces the native speed dropdown** with a custom speed panel (slider + speed dial buttons) supporting speeds up to 16x.

## Features

### End Time Display
Shows \Ends at: HH:MM\ next to the video progress bar on lecture and recording pages. Styled to match Scaler's native control bar.

### Custom Speed Panel
Clicking the speed button opens a custom panel with:
- Slider from 0.1x to 16x with live value display
- Speed dial buttons: 0.5, 1, 1.25, 1.5, 1.75, 2, 2.15, 2.5, 2.75, 3, 3.5, 4, 6, 8, 12, 16x
- Closes on outside click or Escape

### Hotkeys
- Shift + . = speed up by 0.1x
- Shift + , = slow down by 0.1x

## Files Changed
| File | Change |
|------|--------|
| content/features/videoEndTime.js | New |
| manifest.json | Added to content_scripts |
| content/cleaner/selectors.js | Added settings keys |
| content/content.js | Init, handler, URL-change hooks |
| popup.html | Toggle UI with sub-option |
| popup.js | Settings and TOGGLE_MAP |