### PR TITLE
fix: explicitly define execution world for content scripts

### DIFF
--- a/extension-main/manifest.json
+++ b/extension-main/manifest.json
@@ -46,7 +46,8 @@
       "js": [
         "content/core/themePreload.js"
       ],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "world": "ISOLATED"
     },
     {
       "matches": [
@@ -106,7 +107,8 @@
         "content/features/liveStreamRecorder/liveStreamRecorder.css",
         "content/features/vimMode/vimMode.css"
       ],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "world": "ISOLATED"
     }
   ],
   "icons": {


### PR DESCRIPTION
## Summary

Explicitly set `world: "ISOLATED"` for the standard content script blocks to ensure they always execute in the extension's isolated world where Chrome extension APIs (such as `chrome.runtime`) are available.

This preserves the existing `MAIN` world requirement for `vimEditorCapture.js`.

## Verification

- ✅ Export This Problem
- ✅ Export All
- ✅ Homework Export
- ✅ Vim Mode remains functional
- ✅ Test suite passes (100/100)