### PR TITLE
fix: keep logo and Continue Watching titles legible in dark themes (closes #31)

### DIFF
--- a/docs/theme-manager.md
+++ b/docs/theme-manager.md
@@ -83,6 +83,17 @@ There is also a hand-written fix for `.past-events__info::after`, a dark gradien
 root invert turns into a white glow — it is re-authored as a **pre-inverted** white gradient so it
 renders black after inversion.
 
+The card text that sits **on** that scrim (`.past-events__headline`, `.past-events__desc`,
+`.past-events__close-button`) is authored white, so the root invert paints it black — onto a scrim
+we just forced to stay dark. It is pre-inverted the same way (`color: #000` renders white), and the
+two fixes have to move together: keeping the scrim dark is only correct while its text stays light.
+
+Finally, the Scaler wordmark (`img[src*="sst-logo"]`, mounted in the page header and the slide-out
+sidebar) opts **out** of the media un-invert with `filter: none`. It is dark ink on a transparent
+canvas, so un-inverting it — correct for a photo — puts it back to dark-on-dark. The opt-out is
+scoped to that one asset on purpose: a general "small images should invert" rule would also flip
+genuinely dark artwork, which the media rule exists to protect.
+
 ## Per-page decision
 
 Some Scaler pages (the live classroom) are already dark. Inverting those is wrong.

--- a/extension-main/content/features/themeManager.js
+++ b/extension-main/content/features/themeManager.js
@@ -412,6 +412,34 @@ function buildThemeCss(theme, fontUrl) {
         #ffffff
       ) !important;
     }
+
+    /* ...and the card text that SITS on that scrim. Those labels are authored
+       white, so the root invert paints them BLACK — onto a scrim the rule above
+       deliberately keeps dark. The two fixes have to move together: keeping the
+       scrim dark is only correct if its text stays light. Same pre-inversion
+       trick, applied to the color: black here renders WHITE after the root
+       invert (achromatic, so it holds across every dark theme). */
+    html.${r} .past-events__headline,
+    html.${r} .past-events__desc,
+    html.${r} .past-events__close-button {
+      color: #000000 !important;
+    }
+
+    /* The Scaler wordmark is dark navy ink on a TRANSPARENT canvas, so the
+       generic media rule above works against it: the root invert had already
+       made it legible (dark ink -> light ink) and un-inverting it puts it back
+       to dark-on-dark, i.e. invisible against the themed page. Opt it out so it
+       rides the root invert like the surrounding header text does.
+
+       Scoped deliberately narrowly — to this one asset and its two mount points
+       (page header + slide-out sidebar) — rather than to logos in general: a
+       blanket "don't un-invert small images" rule would also flip genuinely
+       dark ARTWORK, which the media rule is there to protect. */
+    html.${r} img[src*="sst-logo"],
+    html.${r} img[alt="sst_logo"],
+    html.${r} .sidebar__header img[alt="logo"] {
+      filter: none !important;
+    }
   `;
 
   if (theme.font && fontUrl) css += buildFontCss(theme.id, fontUrl);

--- a/tests/themeManager.test.js
+++ b/tests/themeManager.test.js
@@ -233,6 +233,67 @@ test("session-card ::after scrim is pre-inverted so it stays a dark shadow (all 
   }
 });
 
+test("session-card text on the scrim is pre-inverted so it stays light (all dark themes)", () => {
+  // Regression (issue #31): .past-events__headline / __desc / __close-button are
+  // authored WHITE, so the root invert paints them black — on top of the scrim
+  // that the rule above deliberately keeps dark, leaving black-on-dark. They must
+  // be re-authored pre-inverted (black → renders white) in every dark theme.
+  for (const id of ["dark", "midnight", "sepia", "dracula", "nord", "solarized"]) {
+    const { window } = loadFeature(THEME_FILE);
+    window.applyTheme(id);
+    const css = window.document.getElementById(STYLE_ID).textContent;
+    const rule = css.match(
+      /\.past-events__headline[^{]*\{[^}]*\}/,
+    );
+    assert.ok(rule, `${id}: past-events text rule present`);
+    for (const sel of ["__headline", "__desc", "__close-button"]) {
+      assert.ok(
+        css.includes(`.past-events${sel}`),
+        `${id}: .past-events${sel} is covered`,
+      );
+    }
+    // Black here renders WHITE after the root invert. A raw #fff would render
+    // black — the bug this guards against.
+    assert.match(rule[0], /color:\s*#000000\s*!important/, `${id}: text pre-inverted to black`);
+    assert.ok(!/color:\s*#fff/i.test(rule[0]), `${id}: text is not authored white`);
+  }
+});
+
+test("the Scaler wordmark opts OUT of the media un-invert so it stays legible", () => {
+  // Regression (issue #31): the logo is dark ink on a transparent canvas. The
+  // generic `img` counter-invert (which exists to keep photos true-coloured) put
+  // it back to dark-on-dark. It must be excluded so it rides the root invert.
+  for (const id of ["dark", "midnight", "sepia", "dracula", "nord", "solarized"]) {
+    const { window } = loadFeature(THEME_FILE);
+    window.applyTheme(id);
+    const css = window.document.getElementById(STYLE_ID).textContent;
+    const rule = css.match(/html\.[\w-]+ img\[src\*="sst-logo"\][^{]*\{[^}]*\}/);
+    assert.ok(rule, `${id}: logo opt-out rule present`);
+    assert.match(rule[0], /filter:\s*none\s*!important/, `${id}: logo is not counter-inverted`);
+    // Both mount points: page header and the slide-out sidebar.
+    assert.ok(rule[0].includes('img[alt="sst_logo"]'), `${id}: header logo covered`);
+    assert.ok(
+      rule[0].includes('.sidebar__header img[alt="logo"]'),
+      `${id}: sidebar logo covered`,
+    );
+  }
+});
+
+test("the logo opt-out is ordered AFTER the generic media un-invert", () => {
+  // Both rules match the same <img> and both are !important, so the cascade is
+  // decided by specificity/order. If the generic `html.x img` rule were emitted
+  // last it would win for any equally-specific match and the logo would go dark
+  // again — so assert the source order the fix depends on.
+  const { window } = loadFeature(THEME_FILE);
+  window.applyTheme("dark");
+  const css = window.document.getElementById(STYLE_ID).textContent;
+  const generic = css.indexOf("html.scaler-theme-active img,");
+  const logo = css.indexOf('img[src*="sst-logo"]');
+  assert.ok(generic !== -1, "generic media rule present");
+  assert.ok(logo !== -1, "logo opt-out present");
+  assert.ok(logo > generic, "logo opt-out comes after the generic media rule");
+});
+
 test("a natively-dark page is left native (no invert applied)", () => {
   // body has its own dark background → the whole page is already dark.
   const html = `<!DOCTYPE html><html><body style="background-color: rgb(14, 14, 18)">


### PR DESCRIPTION
## Problem

Two dark-mode issues reported in #31:

1. The Scaler wordmark in the top-left header is dark navy on the dark themed page — effectively invisible.
2. The **Continue Watching** card titles render **black** on the card thumbnails.

## Root Cause

Both come from the whole-page invert in `buildThemeCss`.

**Logo.** The generic media rule un-inverts every image so photos keep their true colours:

```js
html.scaler-theme-active img { filter: invert(1) hue-rotate(180deg) !important; }
```

That is right for a photo and wrong for this asset. The wordmark is dark ink on a *transparent* canvas — the root invert had already made it legible (dark ink → light ink) and the counter-invert puts it straight back to dark-on-dark. Measured on the raw asset, its opaque pixels have a mean luminance of **0.105**, i.e. near-black.

**Card titles.** This one is a follow-on from #17. That PR re-authored the card scrim as a *pre-inverted* gradient so it stays a dark shadow instead of glowing white:

```js
html.scaler-theme-active .past-events__info::after { /* white stops → render black */ }
```

But the text sitting **on** that scrim was never re-authored. `.past-events__headline`, `.past-events__desc` and `.past-events__close-button` are all authored `rgb(255, 255, 255)`, so the root invert paints them black — onto a backdrop we deliberately keep dark. Black-on-dark is the reported bug.

## Fix

Pre-invert the card text, the same trick already used for the scrim right above it — black here renders white after the root invert, and white is achromatic so it holds across every dark theme:

```css
html.<theme> .past-events__headline,
html.<theme> .past-events__desc,
html.<theme> .past-events__close-button { color: #000000 !important; }
```

Opt the wordmark out of the media un-invert, matching both of its mount points (page header and slide-out sidebar):

```css
html.<theme> img[src*="sst-logo"],
html.<theme> img[alt="sst_logo"],
html.<theme> .sidebar__header img[alt="logo"] { filter: none !important; }
```

The opt-out is scoped to this one asset **on purpose**. A general "small images should invert" rule would also flip genuinely dark artwork, which the media rule exists to protect — so this stays narrow and predictable.

## Testing

- **104/104** unit tests pass (`cd tests && npm test`); 3 are new.
- Red → green confirmed: with the source change reverted, exactly the 3 new tests fail and the 101 pre-existing ones still pass.
- One of the new tests asserts the logo opt-out is emitted **after** the generic media rule — both are `!important` and equally specific, so source order is what makes the fix work.
- Verified against the **running extension** (not injected CSS) on a live logged-in dashboard:
  - `getComputedStyle(logo).filter === "none"` and `.past-events__headline` colour `rgb(0, 0, 0)` in all six dark themes (dark, midnight, dracula, nord, sepia, solarized).
  - With the theme **off**, `buildThemeCss` returns an empty string — no theme CSS is emitted at all, and the headline stays its native `rgb(255, 255, 255)`. Light mode cannot be affected.
- Swept **14 mentee-dashboard routes**. The logo opt-out resolves on every one; `.past-events__*` also appears on class pages (2 and 10 instances there) and renders correctly.

## Scope / notes

- CSS-only change inside `buildThemeCss`. No new files, no new permissions, no manifest changes, no new dependencies.
- No `manifest.json` version bump — that has been maintainer-owned in this repo.
- Docs: updated `docs/theme-manager.md`, alongside the existing scrim note.
- On the "check all of this if possible" part of the issue: I also swept every other counter-inverted image and every authored-white text node on the dashboard. The remaining white text (NEW badges, notification count, Share, Pick Random) sits on coloured chips that invert to light, so it reads fine. Five icons — `bell`, `online_class`, `copy`, `group`, `score` — measure low-contrast but are legible grey line art when zoomed, so I left them alone rather than widen the blast radius. Happy to brighten them in a follow-up if you'd like.

One honest caveat: like the `.past-events__info::after` fix it sits next to, this is selector-based on Scaler's markup. If the `sst-logo` asset or the `past-events` classes are ever renamed, it will silently stop working rather than error.


## Screenshots

Captured against the running extension on a live logged-in dashboard.

**Header logo** — cropped to the left edge, since that is the only region under test:

![logo before and after](https://raw.githubusercontent.com/OfficialAbhinavSingh/Scaler-extension/pr-33-screenshots/pr-logo-before-after.png)

**Continue Watching cards:**

![cards before and after](https://raw.githubusercontent.com/OfficialAbhinavSingh/Scaler-extension/pr-33-screenshots/pr-cards-before-after.png)

**Every theme, including `off`** — `off` is the important row: it shows the native light header and the native white card text, i.e. light mode is provably untouched.

![logo across all themes](https://raw.githubusercontent.com/OfficialAbhinavSingh/Scaler-extension/pr-33-screenshots/strip-logo.png)

![cards across all themes](https://raw.githubusercontent.com/OfficialAbhinavSingh/Scaler-extension/pr-33-screenshots/strip-cw.png)
