### PR TITLE
feat: add live AI tutor for active classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Bypass companion-mode on campus WiFi, download lecture recordings as audio/video
 
 Adds a **"Summary"** tab on the session page that shows an AI-generated summary of the lecture — **Topics taught**, **Notes**, **Deadlines**, and **Announcements** — built from the lecture transcript.
 
+## ✨ Live AI Tutor
+
+During a live class, open **AI Tutor**, add your own transcription and LLM API keys, and select **Start listening**. Scaler++ captures short audio chunks from the active class player, sends them only to the providers you configure, and uses the rolling in-memory transcript plus an optional topic to answer questions such as “What did sir just explain?” or “Can you explain that again?”. Stopping the tutor clears the live transcript and chat context.
+
 ## ⬇️ Lecture Downloader & 📝 AI Transcription
 
 Download recorded lectures directly from the Scaler recordings page as **audio**, **video**, or **transcript** (using your own custom API key for providers like Deepgram, Groq, OpenAI, or ElevenLabs).

--- a/docs/live-ai-tutor.md
+++ b/docs/live-ai-tutor.md
@@ -1,0 +1,22 @@
+# Live AI Tutor
+
+## What it does
+
+The Live AI Tutor is an opt-in floating panel on an active Scaler classroom. A learner provides a transcription endpoint/key and an OpenAI-compatible chat endpoint/key. After the learner presses **Start listening**, Scaler++ captures the audio track exposed by the live video player in 20-second chunks.
+
+Each chunk is sent directly to the learner's chosen transcription provider. The returned text is kept only in the content script's in-memory rolling transcript. When the learner asks a question, the extension sends the recent transcript, the optional current-topic field, and the question to the learner's chosen LLM. The LLM is instructed to answer only from that context and to say when the lecture has not covered the answer.
+
+## Privacy and storage
+
+- No shared API key, server, audio storage, transcript cache, or analytics are used.
+- API credentials are stored in `chrome.storage.local` on the learner's device.
+- Audio leaves the browser only after the learner presses **Start listening**, and only for the transcription endpoint they configured.
+- Stopping or closing the panel stops the recorder and clears the transcript and messages from memory.
+
+## Supported endpoints
+
+The transcription proxy supports Deepgram, ElevenLabs, and OpenAI-compatible transcription endpoints (including Groq). The tutor response uses an OpenAI-compatible `chat/completions` endpoint. The manifest contains host access for the built-in provider presets; a custom endpoint must permit extension-origin requests or be added as a host permission in a future provider-permission flow.
+
+## Limitations
+
+The feature depends on the live player exposing an audio track through `HTMLMediaElement.captureStream()`. If Scaler changes its player or the instructor stream has no accessible audio track, the panel explains that listening cannot start. The current implementation retains only a bounded recent transcript, so it is intentionally a live “what was just explained?” companion rather than a permanent recording archive.

--- a/extension-main/background/background.js
+++ b/extension-main/background/background.js
@@ -13,3 +13,4 @@ importScripts("./videoTracker.js"); // Capture media streams
 importScripts("./calendarSync.js"); // Syncing classes directly into Google Calendar
 importScripts("./messagesProxy.js"); // Proxies CORS requests for custom messages
 importScripts("./summaryProxy.js"); // Lecture summary cache + LLM proxy
+importScripts("./tutorProxy.js"); // Live tutor transcription + LLM proxy

--- a/extension-main/background/tutorProxy.js
+++ b/extension-main/background/tutorProxy.js
@@ -1,0 +1,30 @@
+// Provider-agnostic live-tutor proxy. It only receives short, user-triggered
+// audio chunks and never persists audio, transcript, keys, or answers.
+(function () {
+  function base64ToBlob(base64, mimeType) {
+    const bytes = atob(base64); const data = new Uint8Array(bytes.length);
+    for (let i = 0; i < bytes.length; i += 1) data[i] = bytes.charCodeAt(i);
+    return new Blob([data], { type: mimeType || "audio/webm" });
+  }
+  async function textFromResponse(res) { const body = await res.json(); return body.text || body.results?.channels?.[0]?.alternatives?.[0]?.transcript || body.text || ""; }
+  async function transcribe(blob, config) {
+    const url = config.sttUrl; const model = config.sttModel || (url.includes("groq.com") ? "whisper-large-v3" : "whisper-1");
+    if (url.includes("deepgram.com")) {
+      const res = await fetch(`${url}${url.includes("?") ? "&" : "?"}model=${encodeURIComponent(model)}&smart_format=true`, { method: "POST", headers: { Authorization: `Token ${config.sttKey}`, "Content-Type": blob.type }, body: blob });
+      if (!res.ok) throw new Error(`Transcription provider returned HTTP ${res.status}.`); return textFromResponse(res);
+    }
+    const data = new FormData(); data.append("file", blob, "live-class.webm"); data.append("model", model);
+    const headers = url.includes("elevenlabs.io") ? { "xi-api-key": config.sttKey } : { Authorization: `Bearer ${config.sttKey}` };
+    const res = await fetch(url, { method: "POST", headers, body: data });
+    if (!res.ok) throw new Error(`Transcription provider returned HTTP ${res.status}.`); return textFromResponse(res);
+  }
+  function chatUrl(baseUrl) { const value = (baseUrl || "").trim().replace(/\/+$/, ""); return /\/chat\/completions$/.test(value) ? value : `${value}/chat/completions`; }
+  async function answer(message) {
+    const res = await fetch(chatUrl(message.config.llmUrl), { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${message.config.llmKey}` }, body: JSON.stringify({ model: message.config.llmModel || "gpt-4o-mini", messages: [{ role: "system", content: "You are a secondary tutor during a live class. Answer only from the provided live transcript and topic. If the transcript does not contain enough information, say so clearly and ask the learner to wait for the explanation or provide more context. Be concise and educational." }, { role: "user", content: `Current topic: ${message.topic || "not provided"}\n\nLive transcript:\n${message.transcript}\n\nStudent question: ${message.question}` }] }) });
+    if (!res.ok) throw new Error(`LLM provider returned HTTP ${res.status}.`); const body = await res.json(); return body.choices?.[0]?.message?.content || "I could not find an answer in the live transcript.";
+  }
+  chrome.runtime.onMessage.addListener((message, sender, respond) => {
+    if (message.action === "transcribeLiveTutorAudio") { transcribe(base64ToBlob(message.audio, message.mimeType), message.config).then((text) => respond({ success: true, text })).catch((error) => respond({ success: false, error: error.message })); return true; }
+    if (message.action === "askLiveTutor") { answer(message).then((answer) => respond({ success: true, answer })).catch((error) => respond({ success: false, error: error.message })); return true; }
+  });
+})();

--- a/extension-main/content/content.js
+++ b/extension-main/content/content.js
@@ -169,6 +169,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         // teardown assignment-export: remove buttons
         document.querySelectorAll('.scaler-export-assignment, .scaler-export-question').forEach(el => el.remove());
       }
+    } else if (key === "live-tutor") {
+      if (value) {
+        if (typeof initLiveTutor === "function") initLiveTutor();
+      } else {
+        const tutorButton = document.getElementById("scaler-live-tutor-button"); if (tutorButton) tutorButton.remove();
+        const tutorPanel = document.getElementById("scaler-live-tutor-panel"); if (tutorPanel) tutorPanel.remove();
     } else if (key === "lecture-summary") {
       if (value) {
         if (typeof initLectureSummary === "function") initLectureSummary();
@@ -234,6 +240,9 @@ window.addEventListener("load", async () => {
     }
     if (currentSettings && currentSettings["lecture-summary"] && typeof initLectureSummary === "function") {
       initLectureSummary();
+    }
+    if (currentSettings && currentSettings["live-tutor"] && typeof initLiveTutor === "function") {
+      initLiveTutor();
     }
   }, 1700);
 
@@ -317,6 +326,9 @@ handleUrlChange = function () {
     }
     if (currentSettings && currentSettings["lecture-summary"] && typeof initLectureSummary === "function") {
       initLectureSummary();
+    }
+    if (currentSettings && currentSettings["live-tutor"] && typeof initLiveTutor === "function") {
+      initLiveTutor();
     }
   }, 1700);
 

--- a/extension-main/content/features/liveTutor.js
+++ b/extension-main/content/features/liveTutor.js
@@ -1,0 +1,153 @@
+// Live AI Tutor — opt-in help for an active Scaler classroom.
+// Audio, transcript and answers stay in memory unless the learner explicitly
+// sends an audio chunk to their own transcription provider.
+(function (global) {
+  const BUTTON_ID = "scaler-live-tutor-button";
+  const PANEL_ID = "scaler-live-tutor-panel";
+  const CONFIG_KEY = "scaler_live_tutor_config";
+  const CHUNK_MS = 20_000;
+  const MAX_CONTEXT_CHARS = 24_000;
+  let recorder = null;
+  let stream = null;
+  let transcript = [];
+  let observer = null;
+
+  const send = (message) => new Promise((resolve) => {
+    chrome.runtime.sendMessage(message, (response) => {
+      resolve(chrome.runtime.lastError ? { success: false, error: chrome.runtime.lastError.message } : response || { success: false });
+    });
+  });
+
+  async function config() {
+    const result = await chrome.storage.local.get(CONFIG_KEY);
+    return result[CONFIG_KEY] || {};
+  }
+
+  function isLiveClass() {
+    return /\/academy\/mentee-dashboard\/class\//.test(location.pathname) &&
+      (location.search.includes("joinSession=1") || Boolean(document.querySelector(".agora_video_player, .streams-layout")));
+  }
+
+  function latestContext() {
+    return transcript.map((entry) => `[${entry.time}] ${entry.text}`).join("\n").slice(-MAX_CONTEXT_CHARS);
+  }
+
+  function addStyles() {
+    if (document.getElementById("scaler-live-tutor-styles")) return;
+    const style = document.createElement("style");
+    style.id = "scaler-live-tutor-styles";
+    style.textContent = `
+      #${PANEL_ID}{position:fixed;right:78px;bottom:24px;width:min(390px,calc(100vw - 104px));max-height:70vh;background:#fff;color:#172033;border:1px solid #dbe4f0;border-radius:14px;box-shadow:0 18px 48px rgba(15,23,42,.25);z-index:2147483646;font:14px/1.45 system-ui,sans-serif;overflow:hidden}
+      #${PANEL_ID} *{box-sizing:border-box} .slt-head{display:flex;align-items:center;justify-content:space-between;padding:13px 15px;border-bottom:1px solid #e8edf5;font-weight:750}.slt-head button,.slt-actions button{border:0;border-radius:8px;padding:7px 10px;cursor:pointer;font-weight:650}.slt-body{padding:14px;display:grid;gap:10px}.slt-status{font-size:12px;color:#56657a}.slt-transcript{max-height:130px;overflow:auto;background:#f7f9fc;border-radius:9px;padding:9px;font-size:12px;white-space:pre-wrap}.slt-messages{display:grid;gap:8px;max-height:190px;overflow:auto}.slt-message{padding:9px 10px;border-radius:10px;background:#f0f5ff}.slt-message.user{background:#e7f7ee}.slt-input,.slt-body input{width:100%;border:1px solid #ccd6e4;border-radius:8px;padding:9px;font:inherit}.slt-actions{display:flex;gap:8px;align-items:center}.slt-primary{background:#275df5;color:#fff}.slt-muted{background:#edf1f7;color:#31415a}.slt-config{display:grid;gap:8px;padding-top:4px}.slt-config label{font-size:12px;font-weight:650;color:#48566a}.slt-notice{font-size:11px;color:#6b7788}
+    `;
+    document.head.appendChild(style);
+  }
+
+  function panel() {
+    let el = document.getElementById(PANEL_ID);
+    if (el) return el;
+    addStyles();
+    el = document.createElement("section");
+    el.id = PANEL_ID;
+    el.innerHTML = `<div class="slt-head"><span>✨ Live AI Tutor</span><button class="slt-muted" data-close>×</button></div><div class="slt-body"><div class="slt-status" data-status>Ready. Add your own API keys to start.</div><input data-topic placeholder="Current class topic (optional)" /><div class="slt-actions"><button class="slt-primary" data-start>Start listening</button><button class="slt-muted" data-stop disabled>Stop & clear</button><button class="slt-muted" data-config>Settings</button></div><div class="slt-transcript" data-transcript>Live transcript will appear here. It is cleared when you stop.</div><div class="slt-messages" data-messages></div><div class="slt-actions"><input class="slt-input" data-question placeholder="Ask: What did sir mean by this?" /><button class="slt-primary" data-ask>Ask</button></div><div class="slt-notice">Only the latest audio chunk is sent to your chosen transcription provider. Answers use the recent transcript and your topic.</div></div>`;
+    document.body.appendChild(el);
+    wirePanel(el);
+    return el;
+  }
+
+  function setStatus(el, text) { el.querySelector("[data-status]").textContent = text; }
+  function renderTranscript(el) { el.querySelector("[data-transcript]").textContent = latestContext() || "Live transcript will appear here. It is cleared when you stop."; }
+  function addMessage(el, text, user) { const item = document.createElement("div"); item.className = `slt-message${user ? " user" : ""}`; item.textContent = text; el.querySelector("[data-messages]").appendChild(item); item.scrollIntoView({ block: "nearest" }); }
+
+  async function showConfig(el) {
+    const saved = await config();
+    const body = el.querySelector(".slt-body");
+    if (body.querySelector(".slt-config")) return;
+    const form = document.createElement("div");
+    form.className = "slt-config";
+    form.innerHTML = `<label>Transcription endpoint<input data-stt-url value="${saved.sttUrl || ""}" placeholder="Deepgram, Groq, OpenAI-compatible, or ElevenLabs endpoint" /></label><label>Transcription API key<input type="password" data-stt-key value="${saved.sttKey || ""}" /></label><label>Transcription model (optional)<input data-stt-model value="${saved.sttModel || ""}" /></label><label>LLM base URL<input data-llm-url value="${saved.llmUrl || saved.baseUrl || ""}" placeholder="OpenAI-compatible /v1 URL" /></label><label>LLM API key<input type="password" data-llm-key value="${saved.llmKey || saved.apiKey || ""}" /></label><label>LLM model<input data-llm-model value="${saved.llmModel || saved.model || ""}" placeholder="e.g. llama-3.3-70b-versatile" /></label><button class="slt-primary" data-save>Save keys locally</button>`;
+    body.appendChild(form);
+    form.querySelector("[data-save]").addEventListener("click", async () => {
+      const value = (key) => form.querySelector(`[${key}]`).value.trim();
+      await chrome.storage.local.set({ [CONFIG_KEY]: { sttUrl: value("data-stt-url"), sttKey: value("data-stt-key"), sttModel: value("data-stt-model"), llmUrl: value("data-llm-url"), llmKey: value("data-llm-key"), llmModel: value("data-llm-model") } });
+      form.remove(); setStatus(el, "Settings saved locally in this browser.");
+    });
+  }
+
+  function findAudioStream() {
+    const video = document.querySelector("video.agora_video_player, .agora_video_player video, .streams-layout video");
+    if (!video || typeof video.captureStream !== "function") throw new Error("The live class audio is not ready yet. Start the class video, then try again.");
+    const captured = video.captureStream();
+    const audioTracks = captured.getAudioTracks();
+    if (!audioTracks.length) throw new Error("Could not access class audio. Please make sure the instructor audio is playing.");
+    return new MediaStream(audioTracks);
+  }
+
+  function blobToBase64(blob) { return new Promise((resolve, reject) => { const reader = new FileReader(); reader.onload = () => resolve(String(reader.result).split(",")[1]); reader.onerror = reject; reader.readAsDataURL(blob); }); }
+  function clock() { return new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }); }
+
+  async function transcribeChunk(el, blob) {
+    const saved = await config();
+    if (!saved.sttUrl || !saved.sttKey) { setStatus(el, "Add a transcription endpoint and your own API key in Settings."); stop(el); return; }
+    setStatus(el, "Transcribing the latest 20 seconds with your provider…");
+    const response = await send({ action: "transcribeLiveTutorAudio", audio: await blobToBase64(blob), mimeType: blob.type, config: saved });
+    if (!response.success) { setStatus(el, response.error || "Transcription failed."); return; }
+    if (response.text && response.text.trim()) { transcript.push({ time: clock(), text: response.text.trim() }); renderTranscript(el); setStatus(el, "Listening — recent context is ready for questions."); }
+    else setStatus(el, "Listening — no speech detected in the latest chunk.");
+  }
+
+  async function start(el) {
+    if (recorder) return;
+    try {
+      stream = findAudioStream();
+      const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
+      recorder = new MediaRecorder(stream, { mimeType, audioBitsPerSecond: 48_000 });
+      recorder.addEventListener("dataavailable", (event) => { if (event.data.size) transcribeChunk(el, event.data).catch((e) => setStatus(el, e.message)); });
+      recorder.addEventListener("stop", () => { recorder = null; stream?.getTracks().forEach((track) => track.stop()); stream = null; });
+      recorder.start(CHUNK_MS);
+      el.querySelector("[data-start]").disabled = true; el.querySelector("[data-stop]").disabled = false;
+      setStatus(el, "Listening to the live class. The first transcript chunk arrives in about 20 seconds.");
+    } catch (error) { setStatus(el, error.message || "Could not start live audio capture."); }
+  }
+
+  function stop(el) {
+    if (recorder && recorder.state !== "inactive") recorder.stop();
+    recorder = null; stream?.getTracks().forEach((track) => track.stop()); stream = null; transcript = [];
+    renderTranscript(el); el.querySelector("[data-start]").disabled = false; el.querySelector("[data-stop]").disabled = true;
+    setStatus(el, "Stopped. The live transcript and chat context were cleared.");
+  }
+
+  async function ask(el) {
+    const input = el.querySelector("[data-question]"); const question = input.value.trim();
+    if (!question) return;
+    const context = latestContext(); if (!context) { setStatus(el, "Start listening and wait for a transcript chunk before asking a question."); return; }
+    const saved = await config(); if (!saved.llmUrl || !saved.llmKey) { setStatus(el, "Add your LLM endpoint and API key in Settings."); return; }
+    input.value = ""; addMessage(el, question, true); setStatus(el, "Asking your AI tutor…");
+    const response = await send({ action: "askLiveTutor", question, transcript: context, topic: el.querySelector("[data-topic]").value.trim(), config: saved });
+    if (response.success) { addMessage(el, response.answer, false); setStatus(el, "Answer grounded in the live transcript."); }
+    else setStatus(el, response.error || "The tutor could not answer.");
+  }
+
+  function wirePanel(el) {
+    el.querySelector("[data-close]").addEventListener("click", () => { stop(el); el.remove(); });
+    el.querySelector("[data-start]").addEventListener("click", () => start(el));
+    el.querySelector("[data-stop]").addEventListener("click", () => stop(el));
+    el.querySelector("[data-config]").addEventListener("click", () => showConfig(el));
+    el.querySelector("[data-ask]").addEventListener("click", () => ask(el));
+    el.querySelector("[data-question]").addEventListener("keydown", (event) => { if (event.key === "Enter") ask(el); });
+  }
+
+  function inject() {
+    if (!isLiveClass() || document.getElementById(BUTTON_ID)) return;
+    const actions = document.querySelectorAll(".m-header__actions"); const target = actions[actions.length - 1];
+    if (!target) return;
+    const button = document.createElement("button"); button.id = BUTTON_ID; button.type = "button"; button.textContent = "✨ AI Tutor"; button.className = "tappable btn m-btn m-btn--default"; button.style.cssText = "margin-right:8px;font-weight:650";
+    button.addEventListener("click", () => panel()); target.prepend(button);
+  }
+
+  function initLiveTutor() {
+    inject();
+    if (!observer) { observer = new MutationObserver(inject); observer.observe(document.documentElement, { childList: true, subtree: true }); }
+  }
+  global.initLiveTutor = initLiveTutor;
+})(window);

--- a/extension-main/manifest.json
+++ b/extension-main/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Scaler++",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Bypass companion-mode on campus WiFi, spotlight search, download lecture recordings & declutter Scaler dashboard",
   "permissions": [
     "storage",
@@ -16,7 +16,13 @@
     "*://scaler.com/*",
     "*://*.scaler.com/*",
     "https://www.googleapis.com/calendar/*",
-    "https://scalerbackend.vercel.app/*"
+    "https://scalerbackend.vercel.app/*",
+    "https://api.openai.com/*",
+    "https://api.groq.com/*",
+    "https://api.deepgram.com/*",
+    "https://api.elevenlabs.io/*",
+    "https://generativelanguage.googleapis.com/*",
+    "https://openrouter.ai/*"
   ],
   "oauth2": {
     "client_id": "240142215084-so5ckgh5al2d6aipa0fg9bsokt2gdp61.apps.googleusercontent.com",
@@ -89,6 +95,7 @@
         "content/features/lectureInfo.js",
         "content/features/instructorInfo.js",
         "content/features/lectureSummary.js",
+        "content/features/liveTutor.js",
         "content/features/spotlightSearch.js",
         "content/features/liveStreamRecorder/liveStreamRecorder.js",
         "content/features/themeManager.js",

--- a/extension-main/popup.html
+++ b/extension-main/popup.html
@@ -216,6 +216,17 @@
 
             <label class="toggle-item highlight">
               <div class="toggle-info">
+                <span class="toggle-title">✨ Live AI Tutor</span>
+                <span class="toggle-desc">Ask about the current class using your own transcription and LLM API keys</span>
+              </div>
+              <div class="toggle-switch">
+                <input type="checkbox" id="toggle-live-tutor" checked />
+                <span class="slider"></span>
+              </div>
+            </label>
+
+            <label class="toggle-item highlight">
+              <div class="toggle-info">
                 <span class="toggle-title">🎯 Practice Mode</span>
                 <span class="toggle-desc">Auto-reset code in assignments</span>
               </div>

--- a/extension-main/popup.js
+++ b/extension-main/popup.js
@@ -43,6 +43,7 @@ const DEFAULT_SETTINGS = {
   "lecture-info": true,
   "instructor-info": true,
   "lecture-summary": true,
+  "live-tutor": true,
   "mess-fee-filled-timestamp": null,
 
   // Contest
@@ -84,6 +85,7 @@ const TOGGLE_MAP = {
   "toggle-lecture-info": "lecture-info",
   "toggle-instructor-info": "instructor-info",
   "toggle-lecture-summary": "lecture-summary",
+  "toggle-live-tutor": "live-tutor",
   "toggle-join-session": "join-session",
   "toggle-companion-bypass": "companion-bypass",
   "toggle-companion": "companion",


### PR DESCRIPTION
## What\nAdds an opt-in Live AI Tutor for active Scaler classes. Learners provide their own transcription and LLM API keys, start listening explicitly, and can ask grounded questions using a rolling live transcript plus an optional topic.\n\n## Privacy\n- No shared API key or central audio/transcript storage\n- Audio is sent only to the learner's chosen transcription provider after they click Start listening\n- Stopping or closing the tutor clears in-memory transcript and chat context\n\n## Providers\nSupports Deepgram, ElevenLabs, and OpenAI-compatible transcription endpoints (including Groq), plus OpenAI-compatible chat endpoints.\n\n## Testing\n- 
ode --check for the new content and background scripts\n- Manifest JSON validation\n- 
pm test (repository suite)\n\n## Docs\nUpdated README and added docs/live-ai-tutor.md.